### PR TITLE
Added link to docs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ pip install optimistix
 
 Requires Python 3.9+ and JAX 0.4.14+ and [Equinox](https://github.com/patrick-kidger/equinox) 0.11.0+.
 
+## Documentation
+
+Available at [https://docs.kidger.site/optimistix](https://docs.kidger.site/optimistix).
+
 ## Quick example
 
 ```python


### PR DESCRIPTION
Adds a link to documentation in README, addressing https://github.com/patrick-kidger/optimistix/issues/11.