### PR TITLE
dev

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: ruff
         args: [--fix]
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.329
+    rev: v1.1.330
     hooks:
     - id: pyright
       additional_dependencies: ["equinox", "jax", "lineax", "pytest", "optax"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,25 +13,16 @@
 # limitations under the License.
 
 repos:
-  - repo: https://github.com/ambv/black
-    rev: 22.3.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.7
     hooks:
-    - id: black
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.255'
-    hooks:
-      - id: ruff
-        args: [--fix]
+      - id: ruff  # linter
+        types_or: [ python, pyi, jupyter ]
+        args: [ --fix ]
+      - id: ruff-format  # formatter
+        types_or: [ python, pyi, jupyter ]
   - repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.330
     hooks:
     - id: pyright
       additional_dependencies: ["equinox", "jax", "lineax", "pytest", "optax"]
-  - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.6.3
-    hooks:
-    - id: nbqa-black
-      additional_dependencies: [ipython==8.12, black]
-    - id: nbqa-ruff 
-      args: ["--ignore=I001"]
-      additional_dependencies: [ipython==8.12, ruff]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: ruff-format  # formatter
         types_or: [ python, pyi, jupyter ]
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.330
+    rev: v1.1.331
     hooks:
     - id: pyright
       additional_dependencies: ["equinox", "jax", "lineax", "pytest", "optax"]

--- a/benchmarks/levenberg-marquardt.py
+++ b/benchmarks/levenberg-marquardt.py
@@ -44,9 +44,8 @@ import jax.numpy as jnp
 import jax.scipy as jsp
 import jaxopt  # pyright: ignore
 import lineax as lx
-from jaxtyping import Array, Float
-
 import optimistix as optx
+from jaxtyping import Array, Float
 
 
 def vector_field(

--- a/benchmarks/vmap-unroll.py
+++ b/benchmarks/vmap-unroll.py
@@ -22,7 +22,6 @@ import jax
 import jax.numpy as jnp
 import jax.random as jr
 import jaxopt  # pyright: ignore
-
 import optimistix as optx
 
 

--- a/docs/examples/custom_solver.ipynb
+++ b/docs/examples/custom_solver.ipynb
@@ -32,6 +32,7 @@
    "outputs": [],
    "source": [
     "from collections.abc import Callable\n",
+    "\n",
     "import optimistix as optx\n",
     "\n",
     "\n",

--- a/docs/examples/optimise_diffeq.ipynb
+++ b/docs/examples/optimise_diffeq.ipynb
@@ -25,10 +25,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import jax.numpy as jnp\n",
-    "import matplotlib.pyplot as plt\n",
     "import diffrax as dfx  # https://github.com/patrick-kidger/diffrax\n",
     "import equinox as eqx  # https://github.com/patrick-kidger/equinox\n",
+    "import jax.numpy as jnp\n",
+    "import matplotlib.pyplot as plt\n",
     "import optimistix as optx\n",
     "from jaxtyping import Array, Float  # https://github.com/google/jaxtyping"
    ]

--- a/docs/examples/root_find.ipynb
+++ b/docs/examples/root_find.ipynb
@@ -23,6 +23,7 @@
     "import jax.numpy as jnp\n",
     "import optimistix as optx\n",
     "\n",
+    "\n",
     "# Often import when doing scientific work\n",
     "jax.config.update(\"jax_enable_x64\", True)\n",
     "\n",

--- a/optimistix/_ad.py
+++ b/optimistix/_ad.py
@@ -123,7 +123,7 @@ def _implicit_impl_jvp(primals, tangents):
     )
     _, jvp_diff = jax.jvp(_for_jvp, (diff,), (t_inputs,))
 
-    t_root = (-lx.linear_solve(operator, jvp_diff, linear_solver).value ** ω).ω
+    t_root = (-(lx.linear_solve(operator, jvp_diff, linear_solver).value ** ω)).ω
     t_residual = tree_full_like(residual, 0)
 
     return (root, residual), (t_root, t_residual)

--- a/optimistix/_ad.py
+++ b/optimistix/_ad.py
@@ -88,9 +88,7 @@ def _is_none(x):
 
 
 def _for_jac(root, args):
-    fn_rewrite, residual, _inputs = args
-    iterate, inputs, while_loop = _inputs
-    del iterate, while_loop
+    fn_rewrite, residual, inputs = args
     return fn_rewrite(root, residual, inputs)
 
 
@@ -114,9 +112,7 @@ def _implicit_impl_jvp(primals, tangents):
 
     def _for_jvp(_diff):
         _inputs = eqx.combine(_diff, nondiff)
-        iterate, inputs, while_loop = _inputs
-        del iterate, while_loop
-        return fn_rewrite(root, residual, inputs)
+        return fn_rewrite(root, residual, _inputs)
 
     operator = lx.JacobianLinearOperator(
         _for_jac, root, (fn_rewrite, residual, inputs), tags=tags

--- a/optimistix/_adjoint.py
+++ b/optimistix/_adjoint.py
@@ -142,7 +142,7 @@ class ImplicitAdjoint(AbstractAdjoint):
     $\frac{\mathrm{d}y}{\mathrm{d}\theta} = - (\frac{\mathrm{d}f}{\mathrm{d}y})^{-1}\frac{\mathrm{d}f}{\mathrm{d}\theta}$
     via the implicit function theorem.
 
-    For most problems this is the preferred technique for backpropogating through
+    For most problems this is the preferred technique for backpropagating through
     a nonlinear solve.
     """  # noqa: E501
 

--- a/optimistix/_fixed_point.py
+++ b/optimistix/_fixed_point.py
@@ -73,7 +73,7 @@ def fixed_point(
     max_steps: Optional[int] = 256,
     adjoint: AbstractAdjoint = ImplicitAdjoint(),
     throw: bool = True,
-    tags: frozenset[object] = frozenset()
+    tags: frozenset[object] = frozenset(),
 ) -> Solution[Y, Aux]:
     """Find a fixed-point of a function.
 

--- a/optimistix/_iterate.py
+++ b/optimistix/_iterate.py
@@ -216,8 +216,19 @@ def _zero(x):
         return x
 
 
-def _iterate(inputs, while_loop):
-    fn, solver, y0, args, options, max_steps, f_struct, aux_struct, tags = inputs
+def _iterate(inputs):
+    (
+        fn,
+        solver,
+        y0,
+        args,
+        options,
+        max_steps,
+        f_struct,
+        aux_struct,
+        tags,
+        while_loop,
+    ) = inputs
     del inputs
     static_leaf = lambda x: isinstance(x, eqxi.Static)
     f_struct = jtu.tree_map(lambda x: x.value, f_struct, is_leaf=static_leaf)

--- a/optimistix/_iterate.py
+++ b/optimistix/_iterate.py
@@ -337,13 +337,16 @@ def iterative_solve(
     f_struct = jtu.tree_map(eqxi.Static, f_struct)
     aux_struct = jtu.tree_map(eqxi.Static, aux_struct)
     inputs = fn, solver, y0, args, options, max_steps, f_struct, aux_struct, tags
-    out, (
-        num_steps,
-        result,
-        dynamic_final_state,
-        static_state,
-        aux,
-        stats,
+    (
+        out,
+        (
+            num_steps,
+            result,
+            dynamic_final_state,
+            static_state,
+            aux,
+            stats,
+        ),
     ) = adjoint.apply(_iterate, rewrite_fn, inputs, tags)
     final_state = eqx.combine(dynamic_final_state, unwrap_jaxpr(static_state.value))
     stats = {"num_steps": num_steps, "max_steps": max_steps, **stats}

--- a/optimistix/_misc.py
+++ b/optimistix/_misc.py
@@ -49,7 +49,6 @@ def tree_full_like(
 def tree_full_like(
     struct: PyTree, fill_value: ArrayLike, allow_static: Literal[True] = True
 ):
-
     ...
 
 

--- a/optimistix/_misc.py
+++ b/optimistix/_misc.py
@@ -231,18 +231,16 @@ def filter_cond(pred, true_fun, false_fun, *operands):
         _operands = eqx.combine(_dynamic, static)
         _out = true_fun(*_operands)
         _dynamic_out, _static_out = eqx.partition(_out, eqx.is_array)
-        _static_out = wrap_jaxpr(_static_out)
         return _dynamic_out, eqxi.Static(_static_out)
 
     def _false_fun(_dynamic):
         _operands = eqx.combine(_dynamic, static)
         _out = false_fun(*_operands)
         _dynamic_out, _static_out = eqx.partition(_out, eqx.is_array)
-        _static_out = wrap_jaxpr(_static_out)
         return _dynamic_out, eqxi.Static(_static_out)
 
     dynamic_out, static_out = lax.cond(pred, _true_fun, _false_fun, dynamic)
-    return eqx.combine(dynamic_out, unwrap_jaxpr(static_out.value))
+    return eqx.combine(dynamic_out, static_out.value)
 
 
 def verbose_print(*args: tuple[bool, str, Any]) -> None:

--- a/optimistix/_solver/backtracking.py
+++ b/optimistix/_solver/backtracking.py
@@ -79,7 +79,6 @@ class BacktrackingArmijo(AbstractSearch[Y, _FnInfo, _FnEvalInfo, _BacktrackingSt
         f_eval_info: _FnEvalInfo,
         state: _BacktrackingState,
     ) -> tuple[Scalar, Bool[Array, ""], RESULTS, _BacktrackingState]:
-
         if isinstance(
             f_info,
             (

--- a/optimistix/_solver/bfgs.py
+++ b/optimistix/_solver/bfgs.py
@@ -238,7 +238,9 @@ class AbstractBFGS(AbstractMinimiser[Y, Aux, _BFGSState], Generic[Y, Aux, _Hessi
                 f_eval, grad, state.f_info.grad, hessian, hessian_inv, y_diff
             )
             descent_state = self.descent.query(
-                state.y_eval, f_eval_info, descent_state  # pyright: ignore
+                state.y_eval,
+                f_eval_info,  # pyright: ignore
+                descent_state,
             )
             f_diff = (f_eval**ω - state.f_info.f**ω).ω
             terminate = cauchy_termination(

--- a/optimistix/_solver/dogleg.py
+++ b/optimistix/_solver/dogleg.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 from collections.abc import Callable
-from typing import Any, Generic, Union
+from typing import Any, cast, Generic, Union
 
 import equinox as eqx
 import jax.lax as lax
 import jax.numpy as jnp
 import lineax as lx
 from equinox.internal import ω
-from jaxtyping import PyTree, Scalar
+from jaxtyping import Array, PyTree, Scalar
 
 from .._custom_types import Aux, Out, Y
 from .._misc import (
@@ -102,6 +102,7 @@ class DoglegDescent(
         safe_denom = jnp.where(denom_nonzero, denom, 1)
         # Compute `grad^T grad / (grad^T Hess grad)`
         scaling = jnp.where(denom_nonzero, sum_squares(f_info.grad) / safe_denom, 0.0)
+        scaling = cast(Array, scaling)
 
         # Downhill towards the bottom of the quadratic basin.
         newton_sol, result = newton_step(f_info, self.linear_solver)

--- a/optimistix/_solver/newton_chord.py
+++ b/optimistix/_solver/newton_chord.py
@@ -198,7 +198,9 @@ class _NewtonChord(AbstractRootFinder[Y, Out, Aux, _NewtonChordState[Y]]):
             converged = _converged(factor, self.kappa)
             terminate = at_least_two & (small | diverged | converged)
             terminate_result = RESULTS.where(
-                diverged, RESULTS.nonlinear_divergence, RESULTS.successful
+                jnp.invert(small) & (diverged | jnp.invert(converged)),
+                RESULTS.nonlinear_divergence,
+                RESULTS.successful,
             )
         linsolve_fail = state.result != RESULTS.successful
         result = RESULTS.where(linsolve_fail, state.result, terminate_result)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,14 +46,17 @@ include = ["optimistix/*"]
 addopts = "--jaxtyping-packages=optimistix,beartype.beartype(conf=beartype.BeartypeConf(strategy=beartype.BeartypeStrategy.On))"
 
 [tool.ruff]
-select = ["E", "F", "I001"]
+extend-include = ["*.ipynb"]
+fixable = ["I001", "F401"]
 ignore = ["E402", "E721", "E731", "E741", "F722"]
 ignore-init-module-imports = true
+select = ["E", "F", "I001"]
+src = []
 
 [tool.ruff.isort]
 combine-as-imports = true
-lines-after-imports = 2
 extra-standard-library = ["typing_extensions"]
+lines-after-imports = 2
 order-by-type = false
 
 [tool.pyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "optimistix"
-version = "0.0.5"
+version = "0.0.6"
 description = "Nonlinear optimisation in JAX and Equinox."
 readme = "README.md"
 requires-python ="~=3.9"
@@ -33,7 +33,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 urls = {repository = "https://github.com/patrick-kidger/optimistix" }
-dependencies = ["jax>=0.4.18", "jaxtyping>=0.2.23", "lineax>=0.0.3", "equinox>=0.11.1", "typing_extensions>=4.5.0"]
+dependencies = ["jax>=0.4.18", "jaxtyping>=0.2.23", "lineax>=0.0.4", "equinox>=0.11.1", "typing_extensions>=4.5.0"]
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,38 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import dataclasses
-import random
-
+import equinox.internal as eqxi
 import jax
-import jax.random as jr
 import pytest
-from jaxtyping import PRNGKeyArray
 
 
 jax.config.update("jax_enable_x64", True)
 
 
-# This offers reproducability -- the initial seed is printed in the repr so we can see
-# it when a test fails.
-# Note the `eq=False`, which means that `_GetKey `objects have `__eq__` and `__hash__`
-# based on object identity.
-@dataclasses.dataclass(eq=False)
-class _GetKey:
-    seed: int
-    call: int
-    key: PRNGKeyArray
-
-    def __init__(self, seed: int):
-        self.seed = seed
-        self.call = 0
-        self.key = jr.PRNGKey(seed)
-
-    def __call__(self):
-        self.call += 1
-        return jr.fold_in(self.key, self.call)
-
-
 @pytest.fixture
 def getkey():
-    return _GetKey(random.randint(0, 2**31 - 1))
+    return eqxi.GetKey()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -26,10 +26,9 @@ import jax.tree_util as jtu
 import lineax as lx
 import numpy as np
 import optax
+import optimistix as optx
 from equinox.internal import ω
 from jaxtyping import Array, PyTree, Scalar
-
-import optimistix as optx
 
 
 Y = TypeVar("Y")

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -785,4 +785,4 @@ class PiggybackAdjoint(optx.AbstractAdjoint):
     def apply(self, primal_fn, rewrite_fn, inputs, tags):
         del rewrite_fn, tags
         while_loop = ft.partial(eqxi.while_loop, kind="lax")
-        return primal_fn(inputs, while_loop)
+        return primal_fn(inputs + (while_loop,))

--- a/tests/test_best_so_far.py
+++ b/tests/test_best_so_far.py
@@ -1,5 +1,4 @@
 import jax.numpy as jnp
-
 import optimistix as optx
 
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -28,7 +28,7 @@ def test_minimize(method):
 def test_errors():
     fun, args, x0 = _setup()
     # remove test-time beartype wrapping
-    minimize = optx.compat.minimize.__wrapped__.__wrapped__
+    minimize = optx.compat.minimize.__wrapped__
     with pytest.raises(ValueError):
         minimize(fun, [2.0, 0.0], args, method="bfgs")  # pyright: ignore
 

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,8 +1,7 @@
 import jax.numpy as jnp
 import jax.scipy.optimize as jsp_optimize
-import pytest
-
 import optimistix as optx
+import pytest
 
 from .helpers import beale, tree_allclose
 

--- a/tests/test_fixed_point.py
+++ b/tests/test_fixed_point.py
@@ -4,10 +4,9 @@ import equinox as eqx
 import jax.numpy as jnp
 import jax.random as jr
 import jax.tree_util as jtu
+import optimistix as optx
 import pytest
 from equinox.internal import ω
-
-import optimistix as optx
 
 from .helpers import (
     bisection_fn_init_options_args,

--- a/tests/test_least_squares.py
+++ b/tests/test_least_squares.py
@@ -6,9 +6,8 @@ import jax.numpy as jnp
 import jax.random as jr
 import jax.tree_util as jtu
 import lineax as lx
-import pytest
-
 import optimistix as optx
+import pytest
 
 from .helpers import (
     diagonal_quadratic_bowl,

--- a/tests/test_minimise.py
+++ b/tests/test_minimise.py
@@ -6,9 +6,8 @@ import jax.numpy as jnp
 import jax.random as jr
 import jax.tree_util as jtu
 import optax
-import pytest
-
 import optimistix as optx
+import pytest
 
 from .helpers import (
     beale,

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -14,7 +14,6 @@
 
 import jax
 import jax.numpy as jnp
-
 import optimistix._misc as optx_misc
 
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -13,13 +13,9 @@
 # limitations under the License.
 
 import jax
-import jax.flatten_util as jfu
 import jax.numpy as jnp
 
-import optimistix as optx
 import optimistix._misc as optx_misc
-
-from .helpers import tree_allclose
 
 
 def test_inexact_asarray_no_copy():
@@ -34,58 +30,3 @@ def test_inexact_asarray_jvp():
     p, t = jax.jvp(optx_misc.inexact_asarray, (1.0,), (2.0,))
     assert type(p) is not float
     assert type(t) is not float
-
-
-def test_norm():
-    def _square(x):
-        return x * jnp.conj(x)
-
-    def _two_norm(x):
-        return jnp.sqrt(jnp.sum(_square(jfu.ravel_pytree(x)[0]))).real
-
-    def _rms_norm(x):
-        return jnp.sqrt(jnp.mean(_square(jfu.ravel_pytree(x)[0]))).real
-
-    def _max_norm(x):
-        return jnp.max(jnp.abs(jfu.ravel_pytree(x)[0]))
-
-    x = [jnp.array(1.0), jnp.arange(4.0).reshape(2, 2)]
-    tx = [jnp.array(0.5), jnp.arange(1.0, 5.0).reshape(2, 2)]
-
-    assert jnp.allclose(optx.two_norm(x), _two_norm(x))
-    assert jnp.allclose(optx.rms_norm(x), _rms_norm(x))
-    assert jnp.allclose(optx.max_norm(x), _max_norm(x))
-
-    two = jax.jvp(optx.two_norm, (x,), (tx,))
-    true_two = jax.jvp(_two_norm, (x,), (tx,))
-    rms = jax.jvp(optx.rms_norm, (x,), (tx,))
-    true_rms = jax.jvp(_rms_norm, (x,), (tx,))
-    max = jax.jvp(optx.max_norm, (x,), (tx,))
-    true_max = jax.jvp(_max_norm, (x,), (tx,))
-    assert tree_allclose(two, true_two)
-    assert tree_allclose(rms, true_rms)
-    assert tree_allclose(max, true_max)
-
-    zero = [jnp.array(0.0), jnp.zeros((2, 2))]
-    two0 = jax.jvp(optx.two_norm, (zero,), (tx,))
-    rms0 = jax.jvp(optx.rms_norm, (zero,), (tx,))
-    max0 = jax.jvp(optx.max_norm, (zero,), (tx,))
-    true0 = (jnp.array(0.0), jnp.array(0.0))
-    assert tree_allclose(two0, true0)
-    assert tree_allclose(rms0, true0)
-    assert tree_allclose(max0[0], true0[0])  # tangent rightly has nonzero value
-
-    x = jnp.array([3 + 1.2j, -0.5 + 4.9j])
-    tx = jnp.array([2 - 0.3j, -0.7j])
-    two = jax.jvp(optx.two_norm, (x,), (tx,))
-    true_two = jax.jvp(_two_norm, (x,), (tx,))
-    rms = jax.jvp(optx.rms_norm, (x,), (tx,))
-    true_rms = jax.jvp(_rms_norm, (x,), (tx,))
-    max = jax.jvp(optx.max_norm, (x,), (tx,))
-    true_max = jax.jvp(_max_norm, (x,), (tx,))
-    assert two[0].imag == 0
-    assert tree_allclose(two, true_two)
-    assert rms[0].imag == 0
-    assert tree_allclose(rms, true_rms)
-    assert max[0].imag == 0
-    assert tree_allclose(max, true_max)

--- a/tests/test_root_find.py
+++ b/tests/test_root_find.py
@@ -4,10 +4,9 @@ import equinox as eqx
 import jax.numpy as jnp
 import jax.random as jr
 import jax.tree_util as jtu
+import optimistix as optx
 import pytest
 from equinox.internal import ω
-
-import optimistix as optx
 
 from .helpers import (
     finite_difference_jvp,

--- a/tests/test_root_find.py
+++ b/tests/test_root_find.py
@@ -179,3 +179,13 @@ def test_bad_root_via_min():
     y0 = jnp.array(0.5), jnp.array([-0.3, 0.7])
     sol = optx.root_find(f, optx.BFGS(rtol=1e-8, atol=1e-8), y0, throw=False)
     assert sol.result == optx.RESULTS.nonlinear_max_steps_reached
+
+
+@pytest.mark.parametrize("solver_cls", (optx.Newton, optx.Chord))
+def test_newton_chord_small_diff(solver_cls):
+    def f(y, _):
+        return y
+
+    solver = solver_cls(rtol=1e-5, atol=1e-5, cauchy_termination=False)
+    sol = optx.root_find(f, solver, 0.0, throw=False)
+    assert sol.result == optx.RESULTS.successful

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -1,5 +1,4 @@
 import jax
-
 import optimistix as optx
 
 


### PR DESCRIPTION
- Fixed `{Newton,Chord}(cauchy_termination=False)` failing when started close to the solution
- Fixed `sol.state` including only the dynamic part
- Fixed test function unwrapping with latest jaxtyping
- Moved norms to Lineax
- Updated to use `eqxi.GetKey` and `tree_allclose`
- Switch to ruff-format and ruff for ipynb
- Fixed `implicit_jvp` assuming that it was only being used with iterate
- Now using the same jaxpr in the state.