### PR TITLE
improved OptaxMinimiser docs

### DIFF
--- a/docs/api/minimise.md
+++ b/docs/api/minimise.md
@@ -51,6 +51,8 @@ In addition to the following, note that the [Optax](https://github.com/deepmind/
         members:
             - __init__
 
+`optim` in [`optimistix.OptaxMinimiser`][] is an instance of an Optax minimiser. For example, correct usage is `optimistix.OptaxMinimiser(optax.adam(...), ...)`, not `optimistix.OptaxMinimiser(optax.adam, ...)`. 
+
 ---
 
 ::: optimistix.NonlinearCG

--- a/docs/how-to-choose.md
+++ b/docs/how-to-choose.md
@@ -14,7 +14,7 @@ For relatively "well-behaved" problems -- ones where the initial guess is likely
 
 then the best choice is usually an algorithm like [`optimistix.BFGS`][] or [`optimistix.NonlinearCG`][]. By assuming that your function is relatively well-behaved, then these try to take larger steps to get the minimum faster.
 
-For "messier" problems -- where the surface of the function is not so well-behaved -- then a first-order gradient algorithm often works well. These work by taking many small steps, and never moving too far away from the current best-so-far. The [Optax](https://github.com/deepmind/optax) library is dedicated to such algorithms; as such you should try e.g. `optimistix.OptaxMinimiser(optax.adabelief, learning_rate=1e-3, rtol=1e-8, atol=1e-8)`.
+For "messier" problems -- where the surface of the function is not so well-behaved -- then a first-order gradient algorithm often works well. These work by taking many small steps, and never moving too far away from the current best-so-far. The [Optax](https://github.com/deepmind/optax) library is dedicated to such algorithms; as such you should try e.g. `optimistix.OptaxMinimiser(optax.adabelief(learning_rate=1e-3), rtol=1e-8, atol=1e-8)`.
 
 ## Least-squares problems
 


### PR DESCRIPTION
Fixed the `OptaxMinimiser` example in "how to choose a solver," and provided example usage in the `OptaxMinimiser` description. I think proper usage of `OptaxMinimiser` is a little unclear at the moment, as demonstrated by https://github.com/patrick-kidger/optimistix/issues/21.