### PR TITLE
Check last point when using best so far minimiser

### DIFF
--- a/optimistix/_solver/best_so_far.py
+++ b/optimistix/_solver/best_so_far.py
@@ -113,7 +113,16 @@ class _BestSoFarSolver(AbstractIterativeSolver, Generic[Y, Out, Aux]):
         tags: frozenset[object],
         result: RESULTS,
     ) -> tuple[Y, Aux, dict[str, Any]]:
-        return state.best_y, state.best_aux, {}
+        f, aux = fn(y, args)
+        loss = self._to_loss(y, f)
+
+        best_f, best_aux = fn(state.best_y, args)
+        best_loss = self._to_loss(state.best_y, best_f)
+
+        pred = loss < best_loss
+        best_y = tree_where(pred, y, state.best_y)
+        best_aux = tree_where(pred, aux, state.best_aux)
+        return best_y, best_aux, {}
 
 
 class BestSoFarMinimiser(  # pyright: ignore

--- a/tests/test_best_so_far.py
+++ b/tests/test_best_so_far.py
@@ -41,3 +41,13 @@ def test_minimise():
     solver = optx.BestSoFarMinimiser(solver)
     sol = optx.minimise(fn, solver, jnp.array(0.0))
     assert jnp.allclose(sol.value, 0.96118069, rtol=1e-5, atol=1e-5)
+
+
+def test_checks_last_point():
+    def fn(y, _):
+        return (y - 3.0) ** 2
+
+    solver = optx.BestSoFarMinimiser(optx.BFGS(rtol=1e-5, atol=1e-5))
+    sol = optx.minimise(fn, solver, jnp.array(0.0))
+    assert sol.value == 3.0
+    # assert fn(sol.value, None) <= fn(sol.state.state.y_eval, None)


### PR DESCRIPTION
Fixes #33 

There is some unnecessary looking lines

```
        best_f, best_aux = fn(state.best_y, args)
        best_loss = self._to_loss(state.best_y, best_f)
```

where I would expect to just use `state.best_loss`, but the test doesn't pass without it!