### PR TITLE
Adds a check in order to prevent terminating on first step for functions with initial condition yielding 0 in function evaluation. Corresponding tests.

### DIFF
--- a/optimistix/_solver/bfgs.py
+++ b/optimistix/_solver/bfgs.py
@@ -236,6 +236,9 @@ class AbstractBFGS(
             terminate = cauchy_termination(
                 self.rtol, self.atol, self.norm, state.y_eval, y_diff, f_eval, f_diff
             )
+            terminate = jnp.where(
+                state.first_step, jnp.array(False), terminate
+            )  # Skip termination on first step
             return state.y_eval, f_eval_info, aux_eval, descent_state, terminate
 
         def rejected(descent_state):

--- a/optimistix/_solver/gradient_methods.py
+++ b/optimistix/_solver/gradient_methods.py
@@ -182,6 +182,9 @@ class AbstractGradientDescent(
             terminate = cauchy_termination(
                 self.rtol, self.atol, self.norm, state.y_eval, y_diff, f_eval, f_diff
             )
+            terminate = jnp.where(
+                state.first_step, jnp.array(False), terminate
+            )  # Skip termination on first step
             return state.y_eval, f_eval_info, aux_eval, descent_state, terminate
 
         def rejected(descent_state):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -314,6 +314,11 @@ def simple_nn(model_dynamic: PyTree[Array], args: PyTree):
     return loss(model, x, y)
 
 
+def square_minus_one(x: Array, args: PyTree):
+    """A simple ||x||^2 - 1 function."""
+    return jnp.sum(jnp.square(x)) - 1.0
+
+
 #
 # The MLP can be difficult for some of the solvers to optimise. Rather than set
 # max_steps to a higher value and iterate for longer, we initialise the MLP
@@ -380,7 +385,6 @@ diagonal_bowl_args = treedef.unflatten(
 # neural net args
 ffn_data = jnp.linspace(0, 1, 100)[..., None]
 ffn_args = (ffn_static, ffn_data)
-
 
 least_squares_fn_minima_init_args = (
     (
@@ -456,6 +460,8 @@ minimisation_fn_minima_init_args = (
         [jnp.array(2.0), jnp.array(0.0)],
         (jnp.array(1.5), jnp.array(2.25), jnp.array(2.625)),
     ),
+    # Problems with initial value of 0
+    (square_minus_one, jnp.array(-1.0), jnp.array(1.0), None),
 )
 
 # ROOT FIND/FIXED POINT PROBLEMS


### PR DESCRIPTION
Corresponding to issue #47 which states function whose initial value is zero are considered terminated as a result of their initial function difference value being zero.

As for the commit itself, I'm not sure if using jnp.where is the way since I'm relatively new to jax.