### PR TITLE
Switched from reverse mode to forward mode where possible.

### DIFF
--- a/optimistix/_iterate.py
+++ b/optimistix/_iterate.py
@@ -1,4 +1,5 @@
 import abc
+import warnings
 from collections.abc import Callable
 from typing import Any, Generic, Optional, TYPE_CHECKING
 
@@ -322,6 +323,13 @@ def iterative_solve(
 
     An [`optimistix.Solution`][] object.
     """
+
+    if any(jnp.iscomplexobj(x) for x in jtu.tree_leaves((y0, f_struct))):
+        warnings.warn(
+            "Complex support in Optimistix is a work in progress, and may still return "
+            "incorrect results. You may prefer to split your problem into real and "
+            "imaginary parts, so that Optimistix sees only real numbers."
+        )
 
     f_struct = jtu.tree_map(eqxi.Static, f_struct)
     aux_struct = jtu.tree_map(eqxi.Static, aux_struct)

--- a/optimistix/_solver/gradient_methods.py
+++ b/optimistix/_solver/gradient_methods.py
@@ -58,10 +58,11 @@ class SteepestDescent(AbstractDescent[Y, _FnInfo, _SteepestDescentState], strict
                 FunctionInfo.EvalGrad,
                 FunctionInfo.EvalGradHessian,
                 FunctionInfo.EvalGradHessianInv,
-                FunctionInfo.ResidualJac,
             ),
         ):
             grad = f_info.grad
+        elif isinstance(f_info, FunctionInfo.ResidualJac):
+            grad = f_info.compute_grad()
         else:
             raise ValueError(
                 "Cannot use `SteepestDescent` with this solver. This is because "

--- a/optimistix/_solver/levenberg_marquardt.py
+++ b/optimistix/_solver/levenberg_marquardt.py
@@ -54,7 +54,7 @@ def damped_newton_step(
 
     pred = step_size > jnp.finfo(step_size.dtype).eps
     safe_step_size = jnp.where(pred, step_size, 1)
-    lm_param = jnp.where(pred, 1 / safe_step_size, jnp.finfo(step_size).max)
+    lm_param = jnp.where(pred, 1 / safe_step_size, jnp.finfo(step_size.dtype).max)
     lm_param = cast(Array, lm_param)
     if isinstance(f_info, FunctionInfo.EvalGradHessian):
         operator = f_info.hessian + lm_param * lx.IdentityLinearOperator(

--- a/optimistix/_solver/trust_region.py
+++ b/optimistix/_solver/trust_region.py
@@ -273,7 +273,7 @@ class LinearTrustRegion(
                 FunctionInfo.ResidualJac,
             ),
         ):
-            return tree_dot(f_info.grad, y_diff)
+            return f_info.compute_grad_dot(y_diff)
         else:
             raise ValueError(
                 "Cannot use `LinearTrustRegion` with this solver. This is because "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 urls = {repository = "https://github.com/patrick-kidger/optimistix" }
-dependencies = ["jax>=0.4.28", "jaxtyping>=0.2.23", "lineax>=0.0.4", "equinox>=0.11.1", "typing_extensions>=4.5.0"]
+dependencies = ["jax>=0.4.28", "jaxtyping>=0.2.23", "lineax>=0.0.5", "equinox>=0.11.1", "typing_extensions>=4.5.0"]
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_least_squares.py
+++ b/tests/test_least_squares.py
@@ -149,3 +149,117 @@ def test_gauss_newton_jacrev():
 
     with pytest.raises(TypeError, match="forward-mode autodiff"):
         optx.least_squares(f, solver, y0, options=dict(jac="fwd"), max_steps=512)
+
+
+def test_residual_jac():
+    # We have a `.compute_grad_dot(vec)` method, which computes `grad^T vec`. If you did
+    # this naively this would require reverse-mode autodiff.
+    # However the structure of our problem is such that `grad = jac^T res`, so that in
+    # fact we are computing `res^T jac vec`. This means we can actually compute this
+    # quantity via forward-mode autodiff -- this is more efficient + supports something
+    # things that reverse-mode doesn't, and so doing all of this is the reason that
+    # `.compute_grad_dot` exists.
+    #
+    # However, that's not what this test is really testing.
+    #
+    # The above is all fairly simple to implement. What this test is *really* handling
+    # is that the above all holds true for complex autodiff as well.
+    #
+    # And that is where things get really complicated. It turns out that JAX defines its
+    # complex autodiff like so:
+    # https://jax.readthedocs.io/en/latest/notebooks/autodiff_cookbook.html#complex-numbers-and-differentiation
+    # and notably this means that in the case of a function f=u+iv: C->C, whose gradient
+    # we compute using `jax.grad` (i.e. reverse-mode autodiff with real contangent 1)
+    # then in fact the gradient is computed as `du/dx - i du/dy`. Yup, no `v` dependence
+    # because our cotangent has zero imaginary part. Note that this is
+    # (a) NOT THE SAME as the Wirtinger derivative `df/dz = 0.5 (df/dx - i df/dy)`;
+    # (b) IS THE SAME as the Wirtinger derivative for holomorphic functions. (As for
+    #     such functions, `du/dx - i du/dy = df/dz` by the Cauchy--Riemann equations.)
+    #
+    # Confusingly, JAX decided to go for a non-Wirtinger extension to nonholomorphic
+    # functions. This certainly makes sense from the perspective of complex autodiff as
+    # an extension of real autodiff, but it's still arguably a bit surprising.
+    # For example, the Wirtinger derivative of `0.5 |z|^2 = 0.5 z conj(z)` is
+    # `0.5 conj(z)` (just differentiate wrt `z` ignoring `conj(z)`). However the JAX
+    # derivative is `conj(z)`!
+    #
+    # (Note that we always need to make a choice for how we define complex derivatives
+    # on nonholomorphic functions -- unsurprisingly everyone does at least try to make
+    # their complex derivative be the holomorphic derivative on holomorphic functions,
+    # so that bit at least isn't in doubt. As a reference point, PyTorch defines their
+    # derivative as `conj(dz)`, i.e. the conjugate of the Wirtinger derivative --
+    # which is *not* the same as the conjugate Wirtinger derivative `dconj(z)`. For
+    # example it computes the gradient of `z^2` as `conj(z)`, not `0`:
+    # https://github.com/patrick-kidger/optimistix/pull/61#issuecomment-2169200128)
+
+    # First compute these quantities as complex numbers. In this case the `jax.grad`
+    # gradient (which we are testing that `compute_grad` matches) is given by
+    # `du / dx - i du/dy`. (Note that the quantity we are differentiating is a real
+    # output, so `v=0` anyway.)
+
+    def residual1(y1):
+        return y1**2
+
+    def compute1(y1):
+        r = residual1(y1)
+        jac = lx.MatrixLinearOperator(jax.jacfwd(residual1, holomorphic=True)(y1))
+        f_info = optx.FunctionInfo.ResidualJac(r, jac)
+        return f_info.as_min(), (f_info.compute_grad(), f_info.compute_grad_dot(z))
+
+    y1 = jnp.array([2 + 3j, 4 + 1j])
+    z = jnp.array([-1 + 0j, 2 - 5j])
+    true_min = 0.5 * jnp.sum(y1**2 * jnp.conj(y1**2))
+    (min1, (grad1, grad_dot1)), true_grad1 = jax.value_and_grad(compute1, has_aux=True)(
+        y1
+    )
+    # Convention: put the conjugate on the first argument, as per
+    # https://github.com/patrick-kidger/diffrax/pull/454#issuecomment-2210296643
+    true_grad_dot1 = jnp.sum(jnp.conj(true_grad1) * z)
+
+    # Next compute the same quantities using just the real implementation.
+
+    def residual2(y2):
+        real, imag = y2
+        return real**2 - imag**2, 2 * real * imag
+
+    def compute2(y2):
+        r = residual2(y2)
+        jac = lx.PyTreeLinearOperator(
+            jax.jacfwd(residual2)(y2), jax.eval_shape(lambda: y2)
+        )
+        f_info = optx.FunctionInfo.ResidualJac(r, jac)
+        return f_info.as_min(), (
+            f_info.compute_grad(),
+            f_info.compute_grad_dot((z.real, z.imag)),
+        )
+
+    y2 = (y1.real, y1.imag)
+    (min2, (grad2, grad_dot2)), true_grad2 = jax.value_and_grad(compute2, has_aux=True)(
+        y2
+    )
+    true_grad2_real, true_grad2_imag = true_grad2
+    true_grad_dot2 = jnp.sum(true_grad2_real * z.real + true_grad2_imag * z.imag)
+
+    # Now check consistency.
+
+    assert tree_allclose(min1, min2)
+    assert tree_allclose(min1.astype(jnp.complex128), true_min)
+
+    assert tree_allclose(grad2, true_grad2)
+    assert tree_allclose(grad1, true_grad1)
+    # Note the conjugate! As above the complex derivative is given by `du/dx - i du/dy`,
+    # whilst the real derivative is given by `(du/dx, du/dy)`.
+    assert tree_allclose((grad1.real, -grad1.imag), grad2)
+
+    assert tree_allclose(grad_dot2, true_grad_dot2)
+
+    # TODO: figure out what is going on here, complex numbers don't seem to be behaving.
+    pytest.skip()
+    assert tree_allclose(grad_dot1, true_grad_dot1)
+    # For context, the complex dot product between two scalars is
+    # `(a + bi)^bar . (c + di) = ac + bd + i(ad - bc)`
+    # The real dot product is
+    # `(a, b) . (c, d) = ac + bd`
+    # In general we expect the real part of the complex dot product to agree with the
+    # real dot product.
+    assert tree_allclose(grad_dot1.real, grad_dot2)

--- a/tests/test_solve.py
+++ b/tests/test_solve.py
@@ -1,4 +1,6 @@
+import equinox.internal as eqxi
 import jax
+import jax.numpy as jnp
 import optimistix as optx
 
 
@@ -48,3 +50,16 @@ def test_fixed_point():
         return optx.fixed_point(fn, solver, 0.0).value
 
     f(0.0)
+
+
+def test_forward_mode():
+    def f(y, _):
+        return eqxi.nondifferentiable_backward(y)
+
+    sol = optx.least_squares(
+        f,
+        optx.LevenbergMarquardt(rtol=1e-4, atol=1e-4),
+        jnp.arange(3.0),
+        options=dict(jac="fwd"),
+    )
+    return sol.value


### PR DESCRIPTION
This commit switches some functions that unnecessarily use reverse-mode autodiff to using forward-mode autodiff. In particular this is to fix https://github.com/patrick-kidger/optimistix/pull/51#issuecomment-2124401072.

Whilst I"m here, I noticed what looks like some incorrect handling of complex numbers. I've tried fixing those up, but at least as of this commit the new `test_least_squares.py::test_residual_jac` that I've added actually fails! I've poked at this a bit but not yet been able to resolve this. It seems something is still awry!

Here's some context:
- a least-squares problem returns a "residual vector" `r(y)`. The goal is then to optimise the minimisation problem `0.5*||r(y)||^2` where `||.||` denotes the 2-norm. Whilst you could do this via `optx.minimise`, in practice there are specialised least-squares algorithms that exploit having access to `r`. (Indeed computing this is what occurs in `FunctionInfo.ResidualJac.as_min`, in cases where directly working with the residuals `r` is not necessary.)
- In the complex case this minimisation problem can be written `f(y) = 0.5 * r(y)^T conj(r(y))`.
- The new method `FunctionInfo.ResidualJac.compute_grad` computes the derivative `df/dy = 0.5 * (r^T dconj(r)/dy + dr^T/dy conj(r))`. The jacobian `dr/dy` is available as `FunctionInfo.ResidualJac.jac`
- The test provided implements the same problem using both complex and real (real+imag held separate) numbers. Weirdly, the two reference implementations themselves differ -- not just the version tested in Optimistix! To be precise, the values returned by calling `jax.grad` directly on `FunctionInfo.ResidualJac.as_min` differ by a conjugate! This is the problem :(
- (There is also a method `Function.ResidualJac.compute_grad_dot` that computes the dot-product `df/dy . z` against some vector `z`, i.e. `df/dy^T conj(z)`. I haven't debugged/looked at this at all yet due to the earlier error.)

Tagging @Randl -- do you have a clearer idea of what's going on here?
