### PR TITLE
Remove unused inner function

### DIFF
--- a/optimistix/_solver/bfgs.py
+++ b/optimistix/_solver/bfgs.py
@@ -267,10 +267,6 @@ class AbstractBFGS(
         )
         return y, state, aux
 
-        def make_f_info_on_accept(f_eval, lin_fn):
-            (grad,) = lin_to_grad(lin_fn, y)
-            return f_info
-
     def terminate(
         self,
         fn: Fn[Y, Scalar, Aux],


### PR DESCRIPTION
A little thing I came across while slowly chipping away at my SQP implementation.

This inner function does not seem to be used anywhere, and also does not seem to be an intentional holdover, as far as I can tell.