### PR TITLE
Add dependence mkdocs-autorefs==1.0.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 # Latest versions at time of writing.
 mkdocs==1.3.0            # Main documentation generator.
 mkdocs-material==7.3.6   # Theme
+mkdocs-autorefs==1.0.1   # Specific version to avoid URL conflicts with mkdocstrings
 pymdown-extensions==9.4  # Markdown extensions e.g. to handle LaTeX.
 mkdocstrings==0.17.0     # Autogenerate documentation from docstrings.
 mknotebooks==0.7.1       # Turn Jupyter Lab notebooks into webpages.


### PR DESCRIPTION
This is the last version with which I can build the documentation without error.

1.0.1 came out this February.

If I use 1.1.0, I get: 

```python
Successfully installed mkdocs-autorefs-1.1.0
(.env) optimistix % mkdocs serve
INFO     -  Building documentation...
INFO     -  Cleaning site directory
WARNING  -  Multiple URLs found for 'optimistix.BestSoFarRootFinder':
            ['api/least_squares/#optimistix.BestSoFarRootFinder',
            'api/root_find/#optimistix.BestSoFarRootFinder']. Make sure to use
            unique headings, identifiers, or Markdown anchors (see our docs).

Aborted with 1 warnings in strict mode!
```

And with 1.2.0 I get the previously described error.
This closes https://github.com/patrick-kidger/optimistix/issues/90. 