### PR TITLE
Small bug in BFGS - grad now computed with respect to current iterate in accepted branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ examples/data
 .all_objects.cache
 .pymon
 .idea
+.venv

--- a/optimistix/_misc.py
+++ b/optimistix/_misc.py
@@ -119,9 +119,8 @@ def jacobian(fn, in_size, out_size, has_aux=False):
 
 
 def lin_to_grad(lin_fn, *primals):
-    # Only the shape and dtype of primals is evaluated, not the value itself. lin_fn
-    # already knows where it was computed, and 1.0 acts only as a scaling factor here.
-    # We compute lin_fn and grad separately because it helps us compile efficiently, see
+    # Only the shape and dtype of primals is evaluated, not the value itself. We convert
+    # to grad after linearising to avoid recompilation.
     # https://github.com/patrick-kidger/optimistix/issues/89#issuecomment-2447669714
     return jax.linear_transpose(lin_fn, *primals)(1.0)
 

--- a/optimistix/_misc.py
+++ b/optimistix/_misc.py
@@ -120,7 +120,7 @@ def jacobian(fn, in_size, out_size, has_aux=False):
 
 def lin_to_grad(lin_fn, *primals):
     # Only the shape and dtype of primals is evaluated, not the value itself. We convert
-    # to grad after linearising to avoid recompilation.
+    # to grad after linearising to avoid recompilation. (1.0 is a scaling factor.)
     # https://github.com/patrick-kidger/optimistix/issues/89#issuecomment-2447669714
     return jax.linear_transpose(lin_fn, *primals)(1.0)
 

--- a/optimistix/_misc.py
+++ b/optimistix/_misc.py
@@ -119,6 +119,10 @@ def jacobian(fn, in_size, out_size, has_aux=False):
 
 
 def lin_to_grad(lin_fn, *primals):
+    # Only the shape and dtype of primals is evaluated, not the value itself. lin_fn
+    # already knows where it was computed, and 1.0 acts only as a scaling factor here.
+    # We compute lin_fn and grad separately because it helps us compile efficiently, see
+    # https://github.com/patrick-kidger/optimistix/issues/89#issuecomment-2447669714
     return jax.linear_transpose(lin_fn, *primals)(1.0)
 
 

--- a/optimistix/_solver/bfgs.py
+++ b/optimistix/_solver/bfgs.py
@@ -216,7 +216,7 @@ class AbstractBFGS(
         )
 
         def accepted(descent_state):
-            (grad,) = lin_to_grad(lin_fn, y)
+            (grad,) = lin_to_grad(lin_fn, state.y_eval)
             y_diff = (state.y_eval**ω - y**ω).ω
             if self.use_inverse:
                 hessian = None

--- a/optimistix/_solver/bfgs.py
+++ b/optimistix/_solver/bfgs.py
@@ -216,7 +216,11 @@ class AbstractBFGS(
         )
 
         def accepted(descent_state):
-            (grad,) = lin_to_grad(lin_fn, tree_full_like(y, 0))
+            # We have linearised the function (i.e. computed its Jacobian at y_eval)
+            # above, here we convert it to a gradient of the same shape as y. y_eval is
+            # actually a dummy value here, since lin_fn already has the required info.
+            (grad,) = lin_to_grad(lin_fn, state.y_eval)
+
             y_diff = (state.y_eval**ω - y**ω).ω
             if self.use_inverse:
                 hessian = None

--- a/optimistix/_solver/bfgs.py
+++ b/optimistix/_solver/bfgs.py
@@ -216,7 +216,7 @@ class AbstractBFGS(
         )
 
         def accepted(descent_state):
-            (grad,) = lin_to_grad(lin_fn, state.y_eval)
+            (grad,) = lin_to_grad(lin_fn, tree_full_like(y, 0))
             y_diff = (state.y_eval**ω - y**ω).ω
             if self.use_inverse:
                 hessian = None

--- a/optimistix/_solver/gradient_methods.py
+++ b/optimistix/_solver/gradient_methods.py
@@ -175,7 +175,7 @@ class AbstractGradientDescent(
         )
 
         def accepted(descent_state):
-            (grad,) = lin_to_grad(lin_fn, y)
+            (grad,) = lin_to_grad(lin_fn, state.y_eval)
             f_eval_info = FunctionInfo.EvalGrad(f_eval, grad)
             descent_state = self.descent.query(state.y_eval, f_eval_info, descent_state)
             y_diff = (state.y_eval**ω - y**ω).ω

--- a/optimistix/_solver/gradient_methods.py
+++ b/optimistix/_solver/gradient_methods.py
@@ -175,7 +175,11 @@ class AbstractGradientDescent(
         )
 
         def accepted(descent_state):
-            (grad,) = lin_to_grad(lin_fn, tree_full_like(y, 0))
+            # We have linearised the function (i.e. computed its Jacobian at y_eval)
+            # above, here we convert it to a gradient of the same shape as y. y_eval is
+            # actually a dummy value here, since lin_fn already has the required info.
+            (grad,) = lin_to_grad(lin_fn, state.y_eval)
+
             f_eval_info = FunctionInfo.EvalGrad(f_eval, grad)
             descent_state = self.descent.query(state.y_eval, f_eval_info, descent_state)
             y_diff = (state.y_eval**ω - y**ω).ω

--- a/optimistix/_solver/gradient_methods.py
+++ b/optimistix/_solver/gradient_methods.py
@@ -175,7 +175,7 @@ class AbstractGradientDescent(
         )
 
         def accepted(descent_state):
-            (grad,) = lin_to_grad(lin_fn, state.y_eval)
+            (grad,) = lin_to_grad(lin_fn, tree_full_like(y, 0))
             f_eval_info = FunctionInfo.EvalGrad(f_eval, grad)
             descent_state = self.descent.query(state.y_eval, f_eval_info, descent_state)
             y_diff = (state.y_eval**ω - y**ω).ω


### PR DESCRIPTION
Hi Patrick, 

I think I spotted a small bug in BFGS. 

In the accepted branch, `lin_fn` is passed to `lin_to_grad` with input `y`, which is the last accepted iterate _before_ we decided to accept the current iterate `y_eval`. 
We have linearised `f` at `y_eval`, but are now evaluating this at `y`. 

If I'm not mistaken, then this means that our BFGS update formula implements 

$\nabla f(y_{k}) - \nabla f(y_{k-1})$ instead of $\nabla f(y_{k + 1}) - \nabla f(y_{k})$, where `y_eval` corresponds to $y_{k+1}$.

PS: feel free to disregard the .venv in .gitignore, doesn't need to be in main :) 