### PR TITLE
Add a verbose option to BFGS. 

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -120,6 +120,7 @@ class BFGSDampedNewton(optx.AbstractBFGS):
     use_inverse: bool = False
     search: optx.AbstractSearch = optx.ClassicalTrustRegion()
     descent: optx.AbstractDescent = optx.DampedNewtonDescent()
+    verbose: frozenset[str] = frozenset()
 
 
 class BFGSIndirectDampedNewton(optx.AbstractBFGS):
@@ -131,6 +132,7 @@ class BFGSIndirectDampedNewton(optx.AbstractBFGS):
     use_inverse: bool = False
     search: optx.AbstractSearch = optx.ClassicalTrustRegion()
     descent: optx.AbstractDescent = optx.IndirectDampedNewtonDescent()
+    verbose: frozenset[str] = frozenset()
 
 
 class BFGSDogleg(optx.AbstractBFGS):
@@ -142,6 +144,7 @@ class BFGSDogleg(optx.AbstractBFGS):
     use_inverse: bool = False
     search: optx.AbstractSearch = optx.ClassicalTrustRegion()
     descent: optx.AbstractDescent = optx.DoglegDescent(linear_solver=lx.SVD())
+    verbose: frozenset[str] = frozenset()
 
 
 class BFGSBacktracking(optx.AbstractBFGS):
@@ -153,6 +156,7 @@ class BFGSBacktracking(optx.AbstractBFGS):
     use_inverse: bool = False
     search: optx.AbstractSearch = optx.BacktrackingArmijo()
     descent: optx.AbstractDescent = optx.NewtonDescent()
+    verbose: frozenset[str] = frozenset()
 
 
 class BFGSTrustRegion(optx.AbstractBFGS):
@@ -164,6 +168,7 @@ class BFGSTrustRegion(optx.AbstractBFGS):
     use_inverse: bool = False
     search: optx.AbstractSearch = optx.LinearTrustRegion()
     descent: optx.AbstractDescent = optx.NewtonDescent()
+    verbose: frozenset[str] = frozenset()
 
 
 atol = rtol = 1e-8


### PR DESCRIPTION
Adds a verbose option to BFGS, with supports printing out the values of `loss`, `y`, and `step_size` at every step. 
The tested custom solvers are updated, and the documentation is updated as well. 

Users that have written custom solvers that subclass BFGS will now see `ValueError: The following fields were not initialised during __init__: {'verbose'}` upon upgrading. 

I think this - plus a note in the next release - is probably enough for the subset of users who define custom solvers (and probably know optimistix quite well). It is raised from inside equinox, though, which makes it a little less obvious. I'm happy to improve this - WDYT?

I have "tested" this by using it in a notebook, but not otherwise.

This follows up on https://github.com/patrick-kidger/optimistix/issues/56#issuecomment-2525092603.