### PR TITLE
Best so far swap - `BestSoFarRootFinder` should not be recommended to wrap LeastSquaresSolver 

### DIFF
--- a/docs/api/least_squares.md
+++ b/docs/api/least_squares.md
@@ -55,7 +55,7 @@
 
 ---
 
-::: optimistix.BestSoFarRootFinder
+::: optimistix.BestSoFarLeastSquares
     selection:
         members:
             - __init__

--- a/optimistix/_root_find.py
+++ b/optimistix/_root_find.py
@@ -207,9 +207,6 @@ def root_find(
             adjoint=adjoint,
             throw=throw,
         )
-        _, aux = sol.aux
-        sol = eqx.tree_at(lambda s: s.aux, sol, aux)
-        return sol
     else:
         y0 = jtu.tree_map(inexact_asarray, y0)
         fn = eqx.filter_closure_convert(fn, y0, args)  # pyright: ignore


### PR DESCRIPTION
This fixes a typo in the documentation. `BestSoFarLeastSquares` was undocumented, instead `BestSoFarRootFinder` was the wrapper listed in the section on least squares solvers.

I know that I used it to wrap `LevenbergMarquardt`, and I just checked - this will result in an unexpected solver instance.

```python
import optimistix as optx


solver = optx.GaussNewton(rtol=1e-3, atol=1e-06)
wrapped_ls = optx.BestSoFarLeastSquares(solver)
wrapped_rf = optx.BestSoFarRootFinder(solver)

print(isinstance(wrapped_ls, optx.AbstractLeastSquaresSolver))  # True
print(isinstance(wrapped_rf, optx.AbstractRootFinder))  # True
print(isinstance(wrapped_rf, optx.AbstractLeastSquaresSolver))  # False 
``` 

In this case, it does not appear to do anything as long as `optx.least_squares` is used as the top-level API, because this will only check for a minimiser.

However, if `optx.root_find` is the top-level API and a wrapped least-squares solver is used, then the conversion to `optx.least_squares` won't happen, because this line will not evaluate to `True`:

https://github.com/patrick-kidger/optimistix/blob/1d8e79b5b7cd22f23dde78e9590c43b612849cf4/optimistix/_root_find.py#L197
