### PR TITLE
Adding `__init__` arguments to documentation for descents

### DIFF
--- a/docs/api/searches/descents.md
+++ b/docs/api/searches/descents.md
@@ -10,39 +10,39 @@
 ::: optimistix.SteepestDescent
     selection:
         members:
-            false
+            __init__
 
 ---
 
 ::: optimistix.NonlinearCGDescent
     selection:
         members:
-            false
+            __init__
 
 ---
 
 ::: optimistix.NewtonDescent
     selection:
         members:
-            false
+            __init__
 
 ---
 
 ::: optimistix.DampedNewtonDescent
     selection:
         members:
-            false
+            __init__
 
 ---
 
 ::: optimistix.IndirectDampedNewtonDescent
     selection:
         members:
-            false
+            __init__
 
 ---
 
 ::: optimistix.DoglegDescent
     selection:
         members:
-            false
+            __init__

--- a/docs/api/searches/descents.md
+++ b/docs/api/searches/descents.md
@@ -10,39 +10,39 @@
 ::: optimistix.SteepestDescent
     selection:
         members:
-            __init__
+            - __init__
 
 ---
 
 ::: optimistix.NonlinearCGDescent
     selection:
         members:
-            __init__
+            - __init__
 
 ---
 
 ::: optimistix.NewtonDescent
     selection:
         members:
-            __init__
+            - __init__
 
 ---
 
 ::: optimistix.DampedNewtonDescent
     selection:
         members:
-            __init__
+            - __init__
 
 ---
 
 ::: optimistix.IndirectDampedNewtonDescent
     selection:
         members:
-            __init__
+            - __init__
 
 ---
 
 ::: optimistix.DoglegDescent
     selection:
         members:
-            __init__
+            - __init__

--- a/optimistix/_fixed_point.py
+++ b/optimistix/_fixed_point.py
@@ -101,7 +101,7 @@ def fixed_point(
         an error. If `False` then the returned solution object will have a `result`
         field indicating whether any failures occured. (See [`optimistix.Solution`][].)
         Keyword only argument.
-    - `tags`: Lineax [tags](https://docs.kidger.site/lineax/api/tags/) describing the
+    - `tags`: Lineax [tags](https://docs.kidger.site/lineax/api/tags/) describing
         any structure of the Jacobian of `y -> fn(y, args) - y` with respect to y. (That
         is, the structure of the matrix `dfn/dy - I`.) Used with
         [`optimistix.ImplicitAdjoint`][] to implement the implicit function theorem as

--- a/optimistix/_least_squares.py
+++ b/optimistix/_least_squares.py
@@ -87,7 +87,7 @@ def least_squares(
         an error. If `False` then the returned solution object will have a `result`
         field indicating whether any failures occured. (See [`optimistix.Solution`][].)
         Keyword only argument.
-    - `tags`: Lineax [tags](https://docs.kidger.site/lineax/api/tags/) describing the
+    - `tags`: Lineax [tags](https://docs.kidger.site/lineax/api/tags/) describing
         any structure of the Hessian of `y -> sum(fn(y, args)**2)` with respect to y.
         Used with [`optimistix.ImplicitAdjoint`][] to implement the implicit function
         theorem as efficiently as possible. Keyword only argument.

--- a/optimistix/_minimise.py
+++ b/optimistix/_minimise.py
@@ -30,7 +30,8 @@ def _rewrite_fn(minimum, _, inputs):
     return jax.grad(min_no_aux)(minimum)
 
 
-# Keep `optx.implicit_jvp` is happy.
+# Keep `optx.implicit_jvp` happy.
+# https://github.com/patrick-kidger/optimistix/issues/102#event-15786001854
 if _rewrite_fn.__globals__["__name__"].startswith("jaxtyping"):
     _rewrite_fn = _rewrite_fn.__wrapped__  # pyright: ignore[reportFunctionMemberAccess]
 

--- a/optimistix/_minimise.py
+++ b/optimistix/_minimise.py
@@ -75,7 +75,7 @@ def minimise(
         an error. If `False` then the returned solution object will have a `result`
         field indicating whether any failures occured. (See [`optimistix.Solution`][].)
         Keyword only argument.
-    - `tags`: Lineax [tags](https://docs.kidger.site/lineax/api/tags/) describing the
+    - `tags`: Lineax [tags](https://docs.kidger.site/lineax/api/tags/) describing
         any structure of the Hessian of `fn` with respect to `y`. Used with
         [`optimistix.ImplicitAdjoint`][] to implement the implicit function theorem as
         efficiently as possible. Keyword only argument.

--- a/optimistix/_root_find.py
+++ b/optimistix/_root_find.py
@@ -163,7 +163,7 @@ def root_find(
         an error. If `False` then the returned solution object will have a `result`
         field indicating whether any failures occured. (See [`optimistix.Solution`][].)
         Keyword only argument.
-    - `tags`: Lineax [tags](https://docs.kidger.site/lineax/api/tags/) describing the
+    - `tags`: Lineax [tags](https://docs.kidger.site/lineax/api/tags/) describing
         any structure of the Jacobian of `fn` with respect to `y`. Used with some
         solvers (e.g. [`optimistix.Newton`][]), and with some adjoint methods (e.g.
         [`optimistix.ImplicitAdjoint`][]) to improve the efficiency of linear solves.

--- a/optimistix/_solver/learning_rate.py
+++ b/optimistix/_solver/learning_rate.py
@@ -9,10 +9,14 @@ from .._search import AbstractSearch, FunctionInfo
 from .._solution import RESULTS
 
 
+def _typed_asarray(x: ScalarLike) -> Array:
+    return jnp.asarray(x)
+
+
 class LearningRate(AbstractSearch[Y, FunctionInfo, FunctionInfo, None], strict=True):
     """Move downhill by taking a step of the fixed size `learning_rate`."""
 
-    learning_rate: ScalarLike = eqx.field(converter=jnp.asarray)
+    learning_rate: ScalarLike = eqx.field(converter=_typed_asarray)
 
     def init(self, y: Y, f_info_struct: FunctionInfo) -> None:
         return None

--- a/optimistix/_solver/nonlinear_cg.py
+++ b/optimistix/_solver/nonlinear_cg.py
@@ -164,11 +164,12 @@ class NonlinearCGDescent(
 NonlinearCGDescent.__init__.__doc__ = """**Arguments:**
 
 - `method`: A callable `method(vector, vector_prev, diff_prev)` describing how to
-    calculate the beta parameter of nonlinear CG. Each of these inputs has the meaning
-    described above. The "beta parameter" is the sake as can be described as e.g. the
-    β_n value
-    [on Wikipedia](https://en.wikipedia.org/wiki/Nonlinear_conjugate_gradient_method).
-    In practice Optimistix includes four built-in methods:
+    calculate the beta parameter of nonlinear CG. Nonlinear CG uses the previous search
+    direction, scaled by beta, and subtracts the gradient to find the next search 
+    direction. This parameter, in the nonlinear case, is the same as the parameter β_n
+    described e.g. [on Wikipedia](https://en.wikipedia.org/wiki/Nonlinear_conjugate_gradient_method)
+    for the linear case.
+    Defaults to `polak_ribiere`. Optimistix includes four built-in methods:
     [`optimistix.polak_ribiere`][], [`optimistix.fletcher_reeves`][],
     [`optimistix.hestenes_stiefel`][], and [`optimistix.dai_yuan`][].
 """


### PR DESCRIPTION
Hi Patrick, 

I would like to add documentation for the `__init__` methods of the descents we have.
However, I'm not happy with how this documentation looks like - for instance, we have code that will look something like this

```python
class IndirectDampedNewtonDescent(...):
       root_finder: AbstractRootFinder = Newton(rtol=1e-2, atol=1e-2)
       ...
```

but when building the documentation, all the default arguments to "Newton" are collected as well and make the documentation much harder to read.

The documentation looks like this, blue is the stuff I'd like removed: 

<img width="650" alt="Screenshot 2025-01-10 at 21 22 30" src="https://github.com/user-attachments/assets/81e5f8d7-827c-49fa-8d40-4bd14ec3f2d1" />


I'd like to write a decorator that is similar to `eqxi.docs_remove_args`, but which will instead remove all unchanged default values of arguments that are themselves classes, such that the documentation looks more like the code.

Given that the descent is an `eqx.Module` without an explicit `__init__` method, should this be a class decorator?

I'm opening this as a PR here to provide an example. This can be merged once we have the decorator and be a draft for now. 

(Name of this branch - this was a place to collect little odds and ends that are not critical and don't need their own PR.)