### PR TITLE
Tiny fix: require Python>=3.10, since equinox now does

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,7 +21,7 @@ jobs:
   run-test:
     strategy:
       matrix:
-        python-version: [ 3.10, 3.11 ]
+        python-version: [ "3.10", "3.11" ]
         os: [ ubuntu-latest ]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,7 +21,7 @@ jobs:
   run-test:
     strategy:
       matrix:
-        python-version: [ 3.9, 3.11 ]
+        python-version: [ 3.10, 3.11 ]
         os: [ ubuntu-latest ]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,7 +21,7 @@ jobs:
   run-test:
     strategy:
       matrix:
-        python-version: [ "3.10", "3.11" ]
+        python-version: [ "3.10", "3.12" ]
         os: [ ubuntu-latest ]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ examples/data
 .pymon
 .idea
 .venv
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Features include:
 pip install optimistix
 ```
 
-Requires Python 3.9+ and JAX 0.4.14+ and [Equinox](https://github.com/patrick-kidger/equinox) 0.11.0+.
+Requires Python 3.10+ and JAX 0.4.38+ and [Equinox](https://github.com/patrick-kidger/equinox) 0.11.11+.
 
 ## Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "optimistix"
 version = "0.0.10"
 description = "Nonlinear optimisation in JAX and Equinox."
 readme = "README.md"
-requires-python ="~=3.9"
+requires-python ="~=3.10"
 license = {file = "LICENSE"}
 authors = [
   {name = "Jason Rader", email = "raderjason@outlook.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 urls = {repository = "https://github.com/patrick-kidger/optimistix" }
-dependencies = ["jax>=0.4.28", "jaxtyping>=0.2.23", "lineax>=0.0.6", "equinox>=0.11.7", "typing_extensions>=4.5.0"]
+dependencies = ["jax>=0.4.38", "jaxtyping>=0.2.24", "lineax>=0.0.6", "equinox>=0.11.11", "typing_extensions>=4.5.0"]
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
...and I think that means that everything built on top of equinox should too?