### PR TITLE
Adds an option to support forward-mode automatic differentiation in all minimisers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,4 +25,4 @@ repos:
     rev: v1.1.331
     hooks:
     - id: pyright
-      additional_dependencies: ["equinox", "jax", "lineax", "pytest", "optax"]
+      additional_dependencies: ["equinox", "jax", "lineax", "pytest", "optax", "diffrax"]

--- a/benchmarks/levenberg-marquardt.py
+++ b/benchmarks/levenberg-marquardt.py
@@ -81,7 +81,7 @@ def solve(
         # support forward-mode autodiff, which is used by Levenberg--Marquardt
         adjoint=dfx.DirectAdjoint(),
     )
-    return sol.ys
+    return sol.ys  # pyright: ignore
 
 
 def get_data() -> tuple[Float[Array, "3 2"], Float[Array, "3 50"]]:

--- a/optimistix/_misc.py
+++ b/optimistix/_misc.py
@@ -123,12 +123,12 @@ def _jacfwd(lin_fn, pytree):
         reshaped = jtu.tree_map(lambda a, b: jnp.reshape(a, b.shape), parts, leaves)
         return jtu.tree_unflatten(treedef, reshaped)
 
-    def unit_tree(index):
+    def directional_derivative(index):
         values = jnp.zeros(elements, dtype=dtype).at[index].set(1.0)
-        return values_to_tree(values)
+        unit_tree = values_to_tree(values)
+        return lin_fn(unit_tree)
 
-    unit_pytrees = [unit_tree(i) for i in range(elements)]
-    derivatives = jnp.stack([lin_fn(t) for t in unit_pytrees])
+    derivatives = jax.vmap(directional_derivative)(jnp.arange(elements))
     return values_to_tree(derivatives)
 
 

--- a/optimistix/_misc.py
+++ b/optimistix/_misc.py
@@ -112,7 +112,7 @@ def lin_to_grad(lin_fn, y_eval, mode=None):
         (grad,) = jax.linear_transpose(lin_fn, y_eval)(1.0)  # (1.0 is a scaling factor)
         return grad
     if mode == "fwd":
-        return eqx.filter_jacfwd(lin_fn)(y_eval)
+        return jax.jacfwd(lin_fn)(y_eval)
     else:
         raise ValueError("Only `mode='fwd'` or `mode='bwd'` are valid.")
 

--- a/optimistix/_misc.py
+++ b/optimistix/_misc.py
@@ -105,9 +105,12 @@ class OutAsArray(eqx.Module, strict=True):
 
 
 def _jacfwd(lin_fn, pytree):
-    """Custom version of jax.jacfwd that directly uses a linearized function.
-    Takes inspiration from jax.jacfwd, but simplifies some steps: we only ever treat
-    PyTrees of arrays, where all elements have the same dtype.
+    """Custom version of jax.jacfwd that operates on a linearized function. Enables
+    obtaining a gradient without requiring transposition if the function that was
+    linearized returns a scalar, as in this case the Jacobian is equivalent to the
+    gradient. (Untested for other use cases.)
+    Tailored to the optimistix use-case, where all optimisation variables are pytrees of
+    arrays, sharing the same dtype.
     """
     leaves, treedef = jtu.tree_flatten(pytree)
     static_sizes = [int(jnp.size(leaf)) for leaf in leaves]

--- a/optimistix/_misc.py
+++ b/optimistix/_misc.py
@@ -103,18 +103,20 @@ class OutAsArray(eqx.Module, strict=True):
         return out, aux
 
 
-def lin_to_grad(lin_fn, y_eval, mode=None):
+def lin_to_grad(lin_fn, y_eval, autodiff_mode=None):
     # Only the shape and dtype of y_eval is evaluated, not the value itself. (lin_fn
     # was linearized at y_eval, and the values were stored.)
     # We convert to grad after linearising for efficiency:
     # https://github.com/patrick-kidger/optimistix/issues/89#issuecomment-2447669714
-    if mode == "bwd":
+    if autodiff_mode == "bwd":
         (grad,) = jax.linear_transpose(lin_fn, y_eval)(1.0)  # (1.0 is a scaling factor)
         return grad
-    if mode == "fwd":
+    if autodiff_mode == "fwd":
         return jax.jacfwd(lin_fn)(y_eval)
     else:
-        raise ValueError("Only `mode='fwd'` or `mode='bwd'` are valid.")
+        raise ValueError(
+            "Only `autodiff_mode='fwd'` or `autodiff_mode='bwd'` are valid."
+        )
 
 
 def _asarray(dtype, x):

--- a/optimistix/_solver/bfgs.py
+++ b/optimistix/_solver/bfgs.py
@@ -158,10 +158,10 @@ class AbstractBFGS(
 
     Supports the following `options`:
 
-    - `mode`: whether to use forward- or reverse-mode autodifferentiation to compute the
-        gradient. Can be either `"fwd"` or `"bwd"`. Defaults to `"bwd"`, which is
-        usually more efficient. Changing this can be useful when the target function
-        does not support reverse-mode automatic differentiation.
+    - `autodiff_mode`: whether to use forward- or reverse-mode autodifferentiation to
+        compute the gradient. Can be either `"fwd"` or `"bwd"`. Defaults to `"bwd"`,
+        which is usually more efficient. Changing this can be useful when the target
+        function does not support reverse-mode automatic differentiation.
     """
 
     rtol: AbstractVar[float]
@@ -212,7 +212,7 @@ class AbstractBFGS(
         state: _BFGSState,
         tags: frozenset[object],
     ) -> tuple[Y, _BFGSState, Aux]:
-        mode = options.get("mode", "bwd")
+        autodiff_mode = options.get("autodiff_mode", "bwd")
         f_eval, lin_fn, aux_eval = jax.linearize(
             lambda _y: fn(_y, args), state.y_eval, has_aux=True
         )
@@ -226,7 +226,7 @@ class AbstractBFGS(
         )
 
         def accepted(descent_state):
-            grad = lin_to_grad(lin_fn, state.y_eval, mode=mode)
+            grad = lin_to_grad(lin_fn, state.y_eval, autodiff_mode=autodiff_mode)
 
             y_diff = (state.y_eval**ω - y**ω).ω
             if self.use_inverse:
@@ -326,10 +326,10 @@ class BFGS(AbstractBFGS[Y, Aux, _Hessian], strict=True):
 
     Supports the following `options`:
 
-    - `mode`: whether to use forward- or reverse-mode autodifferentiation to compute the
-        gradient. Can be either `"fwd"` or `"bwd"`. Defaults to `"bwd"`, which is
-        usually more efficient. Changing this can be useful when the target function
-        does not support reverse-mode automatic differentiation.
+    - `autodiff_mode`: whether to use forward- or reverse-mode autodifferentiation to
+        compute the gradient. Can be either `"fwd"` or `"bwd"`. Defaults to `"bwd"`,
+        which is usually more efficient. Changing this can be useful when the target
+        function does not support reverse-mode automatic differentiation.
     """
 
     rtol: float

--- a/optimistix/_solver/gradient_methods.py
+++ b/optimistix/_solver/gradient_methods.py
@@ -123,10 +123,10 @@ class AbstractGradientDescent(
 
     Supports the following `options`:
 
-    - `mode`: whether to use forward- or reverse-mode autodifferentiation to compute the
-        gradient. Can be either `"fwd"` or `"bwd"`. Defaults to `"bwd"`, which is
-        usually more efficient. Changing this can be useful when the target function
-        does not support reverse-mode automatic differentiation.
+    - `autodiff_mode`: whether to use forward- or reverse-mode autodifferentiation to
+        compute the gradient. Can be either `"fwd"` or `"bwd"`. Defaults to `"bwd"`,
+        which is usually more efficient. Changing this can be useful when the target
+        function does not support reverse-mode automatic differentiation.
     """
 
     rtol: AbstractVar[float]
@@ -169,7 +169,7 @@ class AbstractGradientDescent(
         state: _GradientDescentState,
         tags: frozenset[object],
     ) -> tuple[Y, _GradientDescentState, Aux]:
-        mode = options.get("mode", "bwd")
+        autodiff_mode = options.get("autodiff_mode", "bwd")
         f_eval, lin_fn, aux_eval = jax.linearize(
             lambda _y: fn(_y, args), state.y_eval, has_aux=True
         )
@@ -183,7 +183,7 @@ class AbstractGradientDescent(
         )
 
         def accepted(descent_state):
-            grad = lin_to_grad(lin_fn, state.y_eval, mode=mode)
+            grad = lin_to_grad(lin_fn, state.y_eval, autodiff_mode=autodiff_mode)
 
             f_eval_info = FunctionInfo.EvalGrad(f_eval, grad)
             descent_state = self.descent.query(state.y_eval, f_eval_info, descent_state)
@@ -252,10 +252,10 @@ class GradientDescent(AbstractGradientDescent[Y, Aux], strict=True):
 
     Supports the following `options`:
 
-    - `mode`: whether to use forward- or reverse-mode autodifferentiation to compute the
-        gradient. Can be either `"fwd"` or `"bwd"`. Defaults to `"bwd"`, which is
-        usually more efficient. Changing this can be useful when the target function
-        does not support reverse-mode automatic differentiation.
+    - `autodiff_mode`: whether to use forward- or reverse-mode autodifferentiation to
+        compute the gradient. Can be either `"fwd"` or `"bwd"`. Defaults to `"bwd"`,
+        which is usually more efficient. Changing this can be useful when the target
+        function does not support reverse-mode automatic differentiation.
     """
 
     rtol: float

--- a/optimistix/_solver/nonlinear_cg.py
+++ b/optimistix/_solver/nonlinear_cg.py
@@ -175,7 +175,15 @@ NonlinearCGDescent.__init__.__doc__ = """**Arguments:**
 
 
 class NonlinearCG(AbstractGradientDescent[Y, Aux], strict=True):
-    """The nonlinear conjugate gradient method."""
+    """The nonlinear conjugate gradient method.
+
+    Supports the following `options`:
+
+    - `mode`: whether to use forward- or reverse-mode autodifferentiation to compute the
+        gradient. Can be either `"fwd"` or `"bwd"`. Defaults to `"bwd"`, which is
+        usually more efficient. Changing this can be useful when the target function
+        does not support reverse-mode automatic differentiation.
+    """
 
     rtol: float
     atol: float

--- a/optimistix/_solver/nonlinear_cg.py
+++ b/optimistix/_solver/nonlinear_cg.py
@@ -179,10 +179,10 @@ class NonlinearCG(AbstractGradientDescent[Y, Aux], strict=True):
 
     Supports the following `options`:
 
-    - `mode`: whether to use forward- or reverse-mode autodifferentiation to compute the
-        gradient. Can be either `"fwd"` or `"bwd"`. Defaults to `"bwd"`, which is
-        usually more efficient. Changing this can be useful when the target function
-        does not support reverse-mode automatic differentiation.
+    - `autodiff_mode`: whether to use forward- or reverse-mode autodifferentiation to
+        compute the gradient. Can be either `"fwd"` or `"bwd"`. Defaults to `"bwd"`,
+        which is usually more efficient. Changing this can be useful when the target
+        function does not support reverse-mode automatic differentiation.
     """
 
     rtol: float

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,3 +5,4 @@ optax
 pytest
 pytest-xdist
 jaxlib
+diffrax

--- a/tests/test_minimise.py
+++ b/tests/test_minimise.py
@@ -25,9 +25,10 @@ from .helpers import (
 smoke_aux = (jnp.ones((2, 3)), {"smoke_aux": jnp.ones(2)})
 
 
+@pytest.mark.parametrize("options", (dict(mode="fwd"), dict(mode="bwd")))
 @pytest.mark.parametrize("solver", minimisers)
 @pytest.mark.parametrize("_fn, minimum, init, args", minimisation_fn_minima_init_args)
-def test_minimise(solver, _fn, minimum, init, args):
+def test_minimise(solver, _fn, minimum, init, args, options):
     if isinstance(solver, optx.GradientDescent):
         max_steps = 100_000
     else:
@@ -49,6 +50,7 @@ def test_minimise(solver, _fn, minimum, init, args):
             init,
             has_aux=has_aux,
             args=args,
+            options=options,
             max_steps=max_steps,
             throw=False,
         ).value
@@ -56,9 +58,10 @@ def test_minimise(solver, _fn, minimum, init, args):
     assert tree_allclose(optx_min, minimum, atol=atol, rtol=rtol)
 
 
+@pytest.mark.parametrize("options", (dict(mode="fwd"), dict(mode="bwd")))
 @pytest.mark.parametrize("solver", minimisers)
 @pytest.mark.parametrize("_fn, minimum, init, args", minimisation_fn_minima_init_args)
-def test_minimise_jvp(getkey, solver, _fn, minimum, init, args):
+def test_minimise_jvp(getkey, solver, _fn, minimum, init, args, options):
     if isinstance(solver, (optx.GradientDescent, optx.NonlinearCG)):
         max_steps = 100_000
         atol = rtol = 1e-2
@@ -88,6 +91,7 @@ def test_minimise_jvp(getkey, solver, _fn, minimum, init, args):
                 x,
                 has_aux=has_aux,
                 args=args,
+                options=options,
                 max_steps=max_steps,
                 adjoint=adjoint,
                 throw=False,


### PR DESCRIPTION
Minimisers now accept a `"fwd"` and a `"bwd"` option, and `lin_to_grad` will use transposition to get the gradient with reverse-mode, while calling a custom `_jacfwd` that evaluates the linearised function with unit-pytrees when using forward-mode. Where relevant, gradient-computation related documentation has been moved to these two functions.

I have parameterised the tests for `minimise` and `minimise_jvp` to try both options, let me know if there are other tests I should also parameterise. I'm assuming everything else will also work if these two pass.

I have also removed a function `jacobian` from the `_misc` module, that used size-based heuristics to toggle between forward- and reverse-mode automatic differentiation. Since we now support explicit options in all solvers that compute derivatives, this function no longer fits our current way of doing things. (I don't think it was used anywhere anyway.)