### PR TITLE
remove test redundant test case

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -148,18 +148,6 @@ class BFGSDogleg(optx.AbstractBFGS):
     verbose: frozenset[str] = frozenset()
 
 
-class BFGSBacktracking(optx.AbstractBFGS):
-    """Standard BFGS + backtracking line search."""
-
-    rtol: float
-    atol: float
-    norm: Callable = optx.max_norm
-    use_inverse: bool = False
-    search: optx.AbstractSearch = optx.BacktrackingArmijo()
-    descent: optx.AbstractDescent = optx.NewtonDescent()
-    verbose: frozenset[str] = frozenset()
-
-
 class BFGSTrustRegion(optx.AbstractBFGS):
     """Standard BFGS + classical trust region update."""
 
@@ -191,8 +179,6 @@ minimisers = (
     BFGSIndirectDampedNewton(rtol, atol),
     # Tighter tolerance needed to have bfgs_dogleg pass the JVP test.
     BFGSDogleg(1e-10, 1e-10),
-    BFGSBacktracking(rtol, atol, use_inverse=False),
-    BFGSBacktracking(rtol, atol, use_inverse=True),
     BFGSTrustRegion(rtol, atol, use_inverse=False),
     BFGSTrustRegion(rtol, atol, use_inverse=True),
     optx.GradientDescent(1.5e-2, rtol, atol),


### PR DESCRIPTION
`BFGSBacktracking` is the exact same solver as `optx.BFGS`. The only difference is that the specified `NewtonDescent` does not explicitly use `lx.Cholesky`. But since we tag the Hessian operator as positive semidefinite [here](https://github.com/patrick-kidger/optimistix/blob/0fcce03c3f2533e6df6cff9c9835e0110582cbdb/optimistix/_solver/bfgs.py#L104), lineax will still [pick](https://github.com/patrick-kidger/lineax/blob/fa6c777ef6e5edf2c798a58994e07946a3ce50d7/lineax/_solve.py#L582) Cholesky as a solver.