### PR TITLE
Support Optax solvers that include a linesearch

### DIFF
--- a/optimistix/_solver/optax.py
+++ b/optimistix/_solver/optax.py
@@ -97,7 +97,14 @@ class OptaxMinimiser(AbstractMinimiser[Y, Aux, _OptaxState], strict=True):
                 ("loss" in self.verbose, "Loss", f),
                 ("y" in self.verbose, "y", y),
             )
-        updates, new_opt_state = self.optim.update(grads, state.opt_state, y)
+
+        # fix args and discard aux
+        _fn_for_optax = lambda y: fn(y, args)[0]
+        _fn_for_optax = eqx.filter_closure_convert(_fn_for_optax, y)
+
+        updates, new_opt_state = self.optim.update(
+            grads, state.opt_state, y, value=f, grad=grads, value_fn=_fn_for_optax
+        )
         new_y = eqx.apply_updates(y, updates)
         terminate = cauchy_termination(
             self.rtol,


### PR DESCRIPTION
Needed to pass needed keyword arguments to Optax solvers, and make a new function for the `value_fn` to work.

Currently this works with `optax.scale_by_zoom_linesearch` and `optax.lbfgs` which uses that, but does not work with `optax.scaly_by_backtracking_linesearch`. That needs a fix in Optax that I think I have working, and I will send a PR to them about it.

I extended the list of minimizers in the tests. L-BFGS is tested for least squares as well, explicitly chaining SGD + line search is not.
I also added SGD with backtracking linesearch commented out. After the fix on the Optax side, including this should also pass.

Fixes #121 