### PR TITLE
Update workflows: some versions of Github actions sunset today

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -40,7 +40,7 @@ jobs:
           python -m pip install -r ./tests/requirements.txt
 
       - name: Checks with pre-commit
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.1
 
       - name: Test with pytest
         run: |


### PR DESCRIPTION
So it looks like today is the day some actions are sunsetting for good: 

https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts

https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

This PR updates the pre-commit action to a more recent one, but seeing as this is also in maintenance-only mode we should probably migrate to something actively maintained: https://github.com/pre-commit/action