### PR TITLE
LBFGS Hess approx

### DIFF
--- a/optimistix/__init__.py
+++ b/optimistix/__init__.py
@@ -64,6 +64,7 @@ from ._solver import (
     hestenes_stiefel as hestenes_stiefel,
     IndirectDampedNewtonDescent as IndirectDampedNewtonDescent,
     IndirectLevenbergMarquardt as IndirectLevenbergMarquardt,
+    LBFGS as LBFGS,
     LearningRate as LearningRate,
     LevenbergMarquardt as LevenbergMarquardt,
     LinearTrustRegion as LinearTrustRegion,

--- a/optimistix/_search.py
+++ b/optimistix/_search.py
@@ -56,6 +56,7 @@ class FunctionInfo(eqx.Module, strict=eqx.StrictConfig(allow_abstract_name=True)
     EvalGrad: ClassVar[Type["EvalGrad"]]
     EvalGradHessian: ClassVar[Type["EvalGradHessian"]]
     EvalGradHessianInv: ClassVar[Type["EvalGradHessianInv"]]
+    LimitedMemHessianInv: ClassVar[Type["LimitedMemHessianInv"]]
     Residual: ClassVar[Type["Residual"]]
     ResidualJac: ClassVar[Type["ResidualJac"]]
 
@@ -130,6 +131,25 @@ class EvalGradHessianInv(FunctionInfo, Generic[Y], strict=True):
         return tree_dot(self.grad, y)
 
 
+class LimitedMemHessianInv(FunctionInfo, Generic[Y], strict=True):
+    """As [`optimistix.FunctionInfo.HessianInv`][], but records the auxiliary variables
+    for computing the descent direction in LBFGS.
+    Has `.f` and `.grad` and `.params_residuals`, `grad_residuals` attributes.
+    """
+
+    f: Scalar
+    grad: Y
+    params_residuals: Y
+    grad_residuals: Y
+    idx_start: int
+
+    def as_min(self):
+        return self.f
+
+    def compute_grad_dot(self, y: Y):
+        return tree_dot(self.grad, y)
+
+
 # NOT PUBLIC, despite lacking an underscore. This is so pyright gets the name right.
 class Residual(FunctionInfo, Generic[Out], strict=True):
     """Has a `.residual` attribute describing `fn(y)`. Used with least squares problems,
@@ -189,13 +209,14 @@ EvalGradHessian.__qualname__ = "FunctionInfo.EvalGradHessian"
 EvalGradHessianInv.__qualname__ = "FunctionInfo.EvalGradHessianInv"
 Residual.__qualname__ = "FunctionInfo.Residual"
 ResidualJac.__qualname__ = "FunctionInfo.ResidualJac"
+LimitedMemHessianInv.__qualname__ = "FunctionInfo.ResidualJac"
 FunctionInfo.Eval = Eval
 FunctionInfo.EvalGrad = EvalGrad
 FunctionInfo.EvalGradHessian = EvalGradHessian
 FunctionInfo.EvalGradHessianInv = EvalGradHessianInv
 FunctionInfo.Residual = Residual
 FunctionInfo.ResidualJac = ResidualJac
-
+FunctionInfo.LimitedMemHessianInv = LimitedMemHessianInv
 
 Eval.__init__.__doc__ = """**Arguments:**
 

--- a/optimistix/_search.py
+++ b/optimistix/_search.py
@@ -56,7 +56,6 @@ class FunctionInfo(eqx.Module, strict=eqx.StrictConfig(allow_abstract_name=True)
     EvalGrad: ClassVar[Type["EvalGrad"]]
     EvalGradHessian: ClassVar[Type["EvalGradHessian"]]
     EvalGradHessianInv: ClassVar[Type["EvalGradHessianInv"]]
-    LimitedMemHessianInv: ClassVar[Type["LimitedMemHessianInv"]]
     Residual: ClassVar[Type["Residual"]]
     ResidualJac: ClassVar[Type["ResidualJac"]]
 
@@ -131,25 +130,6 @@ class EvalGradHessianInv(FunctionInfo, Generic[Y], strict=True):
         return tree_dot(self.grad, y)
 
 
-class LimitedMemHessianInv(FunctionInfo, Generic[Y], strict=True):
-    """As [`optimistix.FunctionInfo.HessianInv`][], but records the auxiliary variables
-    for computing the descent direction in LBFGS.
-    Has `.f` and `.grad` and `.params_residuals`, `grad_residuals` attributes.
-    """
-
-    f: Scalar
-    grad: Y
-    params_residuals: Y
-    grad_residuals: Y
-    idx_start: int
-
-    def as_min(self):
-        return self.f
-
-    def compute_grad_dot(self, y: Y):
-        return tree_dot(self.grad, y)
-
-
 # NOT PUBLIC, despite lacking an underscore. This is so pyright gets the name right.
 class Residual(FunctionInfo, Generic[Out], strict=True):
     """Has a `.residual` attribute describing `fn(y)`. Used with least squares problems,
@@ -209,14 +189,12 @@ EvalGradHessian.__qualname__ = "FunctionInfo.EvalGradHessian"
 EvalGradHessianInv.__qualname__ = "FunctionInfo.EvalGradHessianInv"
 Residual.__qualname__ = "FunctionInfo.Residual"
 ResidualJac.__qualname__ = "FunctionInfo.ResidualJac"
-LimitedMemHessianInv.__qualname__ = "FunctionInfo.ResidualJac"
 FunctionInfo.Eval = Eval
 FunctionInfo.EvalGrad = EvalGrad
 FunctionInfo.EvalGradHessian = EvalGradHessian
 FunctionInfo.EvalGradHessianInv = EvalGradHessianInv
 FunctionInfo.Residual = Residual
 FunctionInfo.ResidualJac = ResidualJac
-FunctionInfo.LimitedMemHessianInv = LimitedMemHessianInv
 
 Eval.__init__.__doc__ = """**Arguments:**
 

--- a/optimistix/_solver/__init__.py
+++ b/optimistix/_solver/__init__.py
@@ -43,6 +43,7 @@ from .quasi_newton import (
     BFGSUpdate as BFGSUpdate,
     DFP as DFP,
     DFPUpdate as DFPUpdate,
+    LBFGS as LBFGS,
 )
 from .trust_region import (
     ClassicalTrustRegion as ClassicalTrustRegion,

--- a/optimistix/_solver/gauss_newton.py
+++ b/optimistix/_solver/gauss_newton.py
@@ -32,6 +32,7 @@ def newton_step(
     f_info: Union[
         FunctionInfo.EvalGradHessian,
         FunctionInfo.EvalGradHessianInv,
+        FunctionInfo.LimitedMemHessianInv,
         FunctionInfo.ResidualJac,
     ],
     linear_solver: lx.AbstractLinearSolver,

--- a/optimistix/_solver/gauss_newton.py
+++ b/optimistix/_solver/gauss_newton.py
@@ -32,7 +32,6 @@ def newton_step(
     f_info: Union[
         FunctionInfo.EvalGradHessian,
         FunctionInfo.EvalGradHessianInv,
-        FunctionInfo.LimitedMemHessianInv,
         FunctionInfo.ResidualJac,
     ],
     linear_solver: lx.AbstractLinearSolver,

--- a/optimistix/_solver/quasi_newton.py
+++ b/optimistix/_solver/quasi_newton.py
@@ -153,7 +153,7 @@ def _lim_mem_hess_inv_operator(
     op = lx.FunctionLinearOperator(
         operator_func,
         input_shape,
-        tags=lx.positive_semidefinite_tag
+        tags=lx.positive_semidefinite_tag,
     )
     return lx.materialise(op)
 
@@ -387,7 +387,7 @@ class _QuasiNewtonState(
     # Used in compat.py
     num_accepted_steps: Int[Array, ""]
     # update state
-    hess_update_state: dict[Array]
+    hess_update_state: dict
 
 
 

--- a/optimistix/_solver/quasi_newton.py
+++ b/optimistix/_solver/quasi_newton.py
@@ -760,8 +760,8 @@ class LBFGSUpdate(AbstractQuasiNewtonUpdate, strict=True):
         rho = hess_update_state["rho"]
 
         # update states
-        residual_y = residual_y.at[start_index].set(y_diff)
-        residual_grad = residual_grad.at[start_index].set(grad_diff)
+        residual_y = jtu.tree_map(lambda x, z: x.at[start_index].set(z), residual_y, y_diff)
+        residual_grad = jtu.tree_map(lambda x, z: x.at[start_index].set(z), residual_grad, grad_diff)
         rho = rho.at[start_index].set(1. / tree_dot(y_diff, grad_diff))
         rho = jnp.where(jnp.isinf(rho), 0, rho)
 

--- a/optimistix/_solver/quasi_newton.py
+++ b/optimistix/_solver/quasi_newton.py
@@ -127,7 +127,8 @@ def _lim_mem_hess_inv_operator(
     return lx.FunctionLinearOperator(
         operator_func,
         jax.eval_shape(lambda: jtu.tree_map(lambda x: x[0], residual_par)),
-        tags=lx.positive_semidefinite_tag)
+        tags=lx.positive_semidefinite_tag
+    )
 
 
 def _outer(tree1, tree2):
@@ -138,7 +139,7 @@ def _outer(tree1, tree2):
 
 
 _Hessian = TypeVar(
-    "_Hessian", FunctionInfo.EvalGradHessian, FunctionInfo.EvalGradHessianInv, FunctionInfo.LimitedMemHessianInv,
+    "_Hessian", FunctionInfo.EvalGradHessian, FunctionInfo.EvalGradHessianInv,
 )
 
 


### PR DESCRIPTION
## Draft PR: L-BFGS Implementation for `quasi_newton.py`

Hello, and first of all, thank you for the great package!

In this draft PR, I’m working on implementing the **L-BFGS algorithm** within the `quasi_newton.py` module, targeting part of #116 . Before consolidating the code with tests and full integration, I’d appreciate guidance on design decisions.

---

##  Implementation Overview

- The descent direction is computed via `_lim_mem_hess_inv_operator_fn`, which implements the two-loop recursion using the history of parameter and gradient residuals.
- `_lim_mem_hess_inv_operator` acts as an operator factory: it partially evaluates `_lim_mem_hess_inv_operator_fn` with the current residuals and returns a `lineax.FunctionLinearOperator`.
- Currently, the operator is **materialized** before returning, which likely defeats the purpose of using an implicit representation.
- The buffers with the residuals are stored in a pytree of arrays with the same structure as the parameters, but with an additional dimension (of length "buffer size").
- Residuals are stored in a dictionary within `_QuasiNewtonState`.
- The Hessian update returns an additional dictionary carrying the updated residual state.

---

## Questions
1. **Materialization vs. Tree Equality**

    To satisfy this assertion in `_iterate.py`:
    ```python
    assert eqx.tree_equal(static_state, new_static_state) is True
    ```
    I had to materialize the FunctionLinearOperator. Is there a way to avoid this and retain the implicit operator while still passing this check?

2.  The **memory buffer size** is currently **fixed** at 10 iterations. What’s the best way to expose this as a user-settable parameter without altering the broader solver API in `quasi_newton.py`?


3. I did not systematically tested it yet, but for low-dimensional parameters, JIT-compiling the function `_lim_mem_hess_inv_operator_fn` and calling it directly seems significantly faster than the construction of a `FunctionLinearOperator`. Below is line_profiler output for a minimise call:
 
 ```
Timer unit: 1e-06 s

Total time: 0.052245 s
File: /Users/ebalzani/Code/optimistix/optimistix/_solver/quasi_newton.py
Function: _lim_mem_hess_inv_operator at line 120

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   120                                           @line_profiler.profile
   121                                           def _lim_mem_hess_inv_operator(
   122                                                   residual_par: PyTree[Array],
   123                                                   residual_grad: PyTree[Array],
   124                                                   rho: Array,
   125                                                   index_start: Array,
   126                                                   input_shape: Optional[PyTree[jax.ShapeDtypeStruct]] = None,
   127                                           ):
   128                                               """Define a `lineax` linear operator implementing the L-BFGS inverse Hessian approximation.
   129                                           
   130                                               This operator computes the action of the approximate inverse Hessian on a vector `pytree`
   131                                               using the limited-memory BFGS (L-BFGS) two-loop recursion. It does not materialize the matrix
   132                                               explicitly but returns a `lineax.FunctionLinearOperator`.
   133                                           
   134                                               - `residual_par`: History of parameter updates `s_k = x_{k+1} - x_k`
   135                                               - `residual_grad`: History of gradient updates `y_k = g_{k+1} - g_k`
   136                                               - `rho`: Reciprocal dot products `rho_k = 1 / ⟨s_k, y_k⟩`
   137                                               - `index_start`: Index of the most recent update in the circular buffer
   138                                           
   139                                               Returns a `lineax.FunctionLinearOperator` with input and output shape matching a single element
   140                                               of `residual_par`.
   141                                           
   142                                               """
   143         4          2.0      0.5      0.0      operator_func = partial(
   144         2          0.0      0.0      0.0          _lim_mem_hess_inv_operator_fn,
   145         2          0.0      0.0      0.0          residual_par=residual_par,
   146         2          0.0      0.0      0.0          residual_grad=residual_grad,
   147         2          0.0      0.0      0.0          rho=rho,
   148         2          0.0      0.0      0.0          index_start=index_start
   149                                               )
   150         2          0.0      0.0      0.0      input_shape = (
   151         2        942.0    471.0      1.8          jax.eval_shape(lambda: jtu.tree_map(lambda x: x[0], residual_par))
   152         2          0.0      0.0      0.0          if input_shape is None
   153                                                   else input_shape
   154                                               )
   155         4      28219.0   7054.8     54.0      op = lx.FunctionLinearOperator(
   156         2          0.0      0.0      0.0          operator_func,
   157         2          0.0      0.0      0.0          input_shape,
   158         2          1.0      0.5      0.0          tags=lx.positive_semidefinite_tag,
   159                                               )
   160         2      23081.0  11540.5     44.2      return lx.materialise(op)
 ```
 
 
 Let me know how to move on from here and thanks in advance for the insights!
 
 PS tagging my collaborator here too: @bagibence