### PR TITLE
Fixed Gauss-Newton including a spurious `lx.linear_solve(..., throw=True)`

### DIFF
--- a/optimistix/_iterate.py
+++ b/optimistix/_iterate.py
@@ -223,8 +223,8 @@ def _iterate(inputs):
     def cond_fun(carry):
         y, _, dynamic_state, _ = carry
         state = eqx.combine(static_state, dynamic_state)
-        terminate, _ = solver.terminate(fn, y, args, options, state, tags)
-        return jnp.invert(terminate)
+        terminate, result = solver.terminate(fn, y, args, options, state, tags)
+        return jnp.invert(terminate) | (result != RESULTS.successful)
 
     def body_fun(carry):
         y, num_steps, dynamic_state, _ = carry

--- a/optimistix/_solver/gauss_newton.py
+++ b/optimistix/_solver/gauss_newton.py
@@ -73,7 +73,7 @@ def newton_step(
                 "Cannot use a Newton descent with a solver that only evaluates the "
                 "gradient, or only the function itself."
             )
-        out = lx.linear_solve(operator, vector, linear_solver)
+        out = lx.linear_solve(operator, vector, linear_solver, throw=False)
         newton = out.value
         result = RESULTS.promote(out.result)
     return newton, result


### PR DESCRIPTION
And moreover when checking that the new `throw=False` would have any of its failing cases picked up, I noticed that the downstream `AbstractGaussNewton.terminate` method does not actually check the result when deciding whether to terminate. Rather than adjusting just the one solver, I decided to simply lift this condition into the top-level `_iterate.py`.

As such we might consider whether we really need `.terminate` to return both `termintae: bool` and `result: RESULTS`. To consider what each combination means:

- `terminate=True`, `result=RESULTS.successful`: done, and all went well.
- `terminate=True`, `result=RESULTS.foo`: something went wrong; halt.
- `terminate=False`, `result=RESULTS.successfull`: keep making more iterations.
- `terminate=False`, `result=RESULTS.foo`: <invalid>

So we really do need two return arguments: it's not enough to just stop if `result != RESULTS.successful`, because otherwise we have no way to communicate success-and-terminate.

Now we might wonder whether this change produces a change in behaviour. I think technically yes: a solver may have set `terminate=False` and `result=RESULTS.foo`, and then later decided to switch back to being successful. In practice I don't think we ever did that, and it seems pretty sketchy anyway.