### PR TITLE
Anderson acceleration methods

### DIFF
--- a/benchmarks/test_timing_anderson.py
+++ b/benchmarks/test_timing_anderson.py
@@ -1,0 +1,62 @@
+# Some tests to see the impact of the linear solver on the progression of
+# the anderson solver.
+from timeit import default_timer
+
+import jax
+import jaxtyping as jt
+import lineax as lx
+import optimistix as optx
+
+
+@jax.jit
+def test_function(x: jt.PyTree, *args):
+    del args
+    return {
+        "a": (x["a"] - 1.0) * (jax.nn.tanh(x["b"][0]) - x["b"][1]),
+        "b": (x["b"][0], jax.lax.cos(x["b"][1])),
+    }
+
+
+def time_solver(key: jt.PRNGKeyArray, lin_solver: lx.AbstractLinearSolver | None):
+    solver: optx.AbstractFixedPointSolver
+    if lin_solver is None:
+        solver = optx.FixedPointIteration(1e-4, 1e-4)
+    else:
+        solver = optx.AndersonAcceleration(
+            1e-4, 1e-4, mixing=0.5, linear_solver=lin_solver
+        )
+
+    @jax.jit
+    @jax.vmap
+    def solve(start: jt.PyTree) -> jt.PyTree:
+        sol = optx.fixed_point(
+            test_function, solver, start, throw=False, max_steps=10000
+        )
+        return sol.stats["num_steps"]
+
+    y0 = {
+        "a": jax.numpy.zeros((1000, 3, 4, 2)),
+        "b": (
+            jax.random.normal(key, (1000, 2)) / 10,
+            jax.random.normal(key, (1000, 2)) / 10,
+        ),
+    }
+    solve(y0)
+
+    t0 = default_timer()
+    stats = solve(y0)
+    dt = default_timer() - t0
+
+    stps = stats.mean().item()
+    return dt / stps, dt, stps
+
+
+if __name__ == "__main__":
+    key = jax.random.key(666)
+    print("FixedPointIteration:", time_solver(key, None))
+    print("NCG:", time_solver(key, lx.NormalCG(1e-4, 1e-4)))
+    print("BiCG:", time_solver(key, lx.BiCGStab(1e-4, 1e-4)))
+    print("GMRES:", time_solver(key, lx.GMRES(1e-4, 1e-4)))
+    print("SVD:", time_solver(key, lx.SVD()))
+    print("LU:", time_solver(key, lx.LU()))
+    print("QR:", time_solver(key, lx.QR()))

--- a/optimistix/__init__.py
+++ b/optimistix/__init__.py
@@ -41,6 +41,7 @@ from ._solver import (
     AbstractGradientDescent as AbstractGradientDescent,
     AbstractQuasiNewton as AbstractQuasiNewton,
     AbstractQuasiNewtonUpdate as AbstractQuasiNewtonUpdate,
+    AndersonAcceleration as AndersonAcceleration,
     BacktrackingArmijo as BacktrackingArmijo,
     BestSoFarFixedPoint as BestSoFarFixedPoint,
     BestSoFarLeastSquares as BestSoFarLeastSquares,

--- a/optimistix/_solver/__init__.py
+++ b/optimistix/_solver/__init__.py
@@ -1,3 +1,6 @@
+from .anderson_accelerated_fixedpoint import (
+    AndersonAcceleration as AndersonAcceleration,
+)
 from .backtracking import BacktrackingArmijo as BacktrackingArmijo
 from .best_so_far import (
     BestSoFarFixedPoint as BestSoFarFixedPoint,

--- a/optimistix/_solver/anderson_accelerated_fixedpoint.py
+++ b/optimistix/_solver/anderson_accelerated_fixedpoint.py
@@ -1,0 +1,254 @@
+from collections.abc import Callable
+from typing import Any, Generic
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import lineax as lx
+from equinox.internal import ω
+from jaxtyping import Array, Bool, Int, PyTree, Scalar
+
+from .._custom_types import Aux, Fn, Y
+from .._fixed_point import AbstractFixedPointSolver
+from .._misc import max_norm
+from .._solution import RESULTS
+
+
+class _AndersonAccelFixedPointState(eqx.Module, Generic[Y]):
+    relative_error: Scalar
+    past_errors: Y
+    past_iterates: Y
+    right_hand_side: tuple[Scalar, Array]
+    current_iter: Int[Array, ""]
+
+
+class AndersonAcceleration(
+    AbstractFixedPointSolver[Y, Aux, _AndersonAccelFixedPointState]
+):
+    r"""Repeatedly calls a function in search of a fixed point.
+
+    Unlike the usual fixed point iterations that simply
+    repeatedly call `y_{n+1}=f(y_n)` until `y_n` stops changing,
+    Anderson methods attempt to blend residuals (`f(y_k)-y_k`) and
+    iterates (`y_k`) from a window of past iterations to produce
+    the next iterate.
+
+    The update formula amounts to finding `α` solving the following
+    optimisation problem.
+
+    ```
+    min || G.α ||^2
+    s.t. 1^T.α = 1
+         G = [*residuals_past]
+    ```
+    The KKT conditions of this problem yield a system of linear equations to
+    solve at each iteration, of size `dim(y)+1`.
+    ```
+    [ 0  1^T  ] [ν]   [1]
+    [         ] [ ]   [ ]
+    [ 1 G^T.G ] [α] = [0]
+    [         ] [ ]   [ ]
+    ```
+    Then combine the past residuals and iterates:
+    ```
+    new_y = β * dot(G, α) + dot([*y_past], α)
+    ```
+
+    See e.g.
+        - [this tutorial](https://implicit-layers-tutorial.org/implicit_functions/).
+        - [[Fang and Saad, 2009]](https://onlinelibrary.wiley.com/doi/10.1002/nla.617)
+        - [[Walker and Ni, 2011]](https://users.wpi.edu/~walker/Papers/Walker-Ni,SINUM,V49,1715-1735.pdf)
+    """
+
+    rtol: float
+    atol: float
+    norm: Callable[[PyTree], Scalar] = max_norm
+    # Beta coefficient for damping
+    mixing: float = 0.5
+    memory_size: int = 10
+    # Regularization factor to lift up the smallest e.v. of the normal equations:
+    # Cf. doi.org/10.1016/j.anucene.2024.110837 eq (42)->(43)
+    regularization: float = 1e-6
+    linear_solver: lx.AbstractLinearSolver = lx.LU()
+
+    def init(
+        self,
+        fn: Fn[Y, Y, Aux],
+        y: Y,
+        args: PyTree,
+        options: dict[str, Any],
+        f_struct: PyTree[jax.ShapeDtypeStruct],
+        aux_struct: PyTree[jax.ShapeDtypeStruct],
+        tags: frozenset[object],
+    ) -> _AndersonAccelFixedPointState:
+        del options, f_struct, aux_struct, tags
+        fn_output, _ = fn(y, args)
+
+        with jax.numpy_dtype_promotion("standard"):
+            # The matrix involved in the normal equations (G)
+            error_memory_init = jax.tree.map(
+                lambda _f, _y: jnp.stack([_f - _y] * self.memory_size, axis=0),
+                fn_output,
+                y,
+            )
+            # [z_k, z_{k-1}, ...]
+            iterates_memory_init = jax.tree.map(
+                lambda _y: jnp.stack([_y] * self.memory_size, axis=0), y
+            )
+            # Get the kind of (nu, alpha) combination wished for, by computing
+            # the dtype of the output. _infos contains the dtype of a scalar that
+            # corresponds to the sum of all the coordinates (in pytree form) of
+            # the function's output
+            _infos = jax.eval_shape(
+                lambda _y: jax.tree.reduce(jnp.add, (_y**ω).call(jnp.sum).ω), fn_output
+            )
+        # Now that we used context management to get the "common dtype" of the
+        # outputs of the function, i.e. of the linear system to solve, we can
+        # build the right hand side of the normal equations
+        right_hand_side = (
+            jnp.ones_like(_infos),
+            jnp.zeros((self.memory_size,)).astype(_infos.dtype),
+        )
+        return _AndersonAccelFixedPointState(
+            jnp.array(jnp.inf),
+            error_memory_init,
+            iterates_memory_init,
+            right_hand_side,
+            jnp.array(1),
+        )
+
+    def step(
+        self,
+        fn: Fn[Y, Y, Aux],
+        y: Y,
+        args: PyTree,
+        options: dict[str, Any],
+        state: _AndersonAccelFixedPointState,
+        tags: frozenset[object],
+    ) -> tuple[Y, _AndersonAccelFixedPointState, Aux]:
+        del tags
+        fn_output, aux = fn(y, args)
+        error = y**ω - fn_output**ω
+
+        # Update the rolling memory without shifting the data
+        new_errors_memory: Y = jax.tree.map(
+            lambda olds_, new_: olds_.at[state.current_iter % self.memory_size].set(
+                new_
+            ),
+            state.past_errors,
+            error.ω,
+        )
+        new_iterates_memory: Y = jax.tree.map(
+            lambda olds_, new_: olds_.at[state.current_iter % self.memory_size].set(
+                new_
+            ),
+            state.past_iterates,
+            fn_output,
+        )
+        with jax.numpy_dtype_promotion("standard"):
+
+            def kkt_linear_op(
+                optim_vector: tuple[Scalar, Array],
+            ) -> tuple[Scalar, Array]:
+                """
+                Solve:
+                [ 0 1...1 ] ( ν )   ( 1 )
+                | 1       | |   |   | 0 |
+                | : G^T.G | | α | = | : |
+                [ 1       ] (   )   ( 0 )
+                This function describes the left operator.
+                """
+                nu, alpha = optim_vector
+                normal_equation = nu + jax.tree.reduce(
+                    lambda _carry, _errs: _carry
+                    + jnp.einsum("j...,i...,i->j", _errs, _errs, alpha),
+                    new_errors_memory,
+                    initializer=jnp.array(0.0),
+                )
+                return (jnp.sum(alpha), normal_equation + self.regularization * alpha)
+
+            # Pointer to the right-hand side of the equations
+            rhs = state.right_hand_side
+
+            solution = lx.linear_solve(
+                # In case the user wishes to use GMRES/NormalCG as solver,
+                # we define the linear operator lazily without materializing the
+                # matrix
+                lx.FunctionLinearOperator(
+                    kkt_linear_op,
+                    jax.eval_shape(lambda: rhs),
+                    # The normal equations matrix is always at least symmetric.
+                    # It has one negative eigenvalue, and n positive ones.
+                    tags=frozenset({lx.symmetric_tag}),
+                ),
+                rhs,
+                self.linear_solver,
+                throw=False,
+                options=options,
+            )
+            _, weighting = solution.value
+
+            # New iterate is G.α
+            new_y = jax.tree.map(
+                eqx.Partial(self._combine_iters, weighting),
+                new_errors_memory,
+                new_iterates_memory,
+            )
+
+            scale = self.atol + self.rtol * ω(new_y).call(jnp.abs)
+            new_state = _AndersonAccelFixedPointState(
+                self.norm((error / scale).ω),
+                new_errors_memory,
+                new_iterates_memory,
+                state.right_hand_side,
+                state.current_iter + 1,
+            )
+        return new_y, new_state, aux
+
+    def _combine_iters(
+        self, weighting: Array, errors: PyTree[Array], iters: PyTree[Array]
+    ):
+        # Helper function to combine past iterates and past residuals into next
+        # iterates.
+        return jnp.einsum("i...,i->...", iters + self.mixing * errors, weighting)
+
+    def terminate(
+        self,
+        fn: Fn[Y, Y, Aux],
+        y: Y,
+        args: PyTree,
+        options: dict[str, Any],
+        state: _AndersonAccelFixedPointState,
+        tags: frozenset[object],
+    ) -> tuple[Bool[Array, ""], RESULTS]:
+        return state.relative_error < 1, RESULTS.successful
+
+    def postprocess(
+        self,
+        fn: Fn[Y, Y, Aux],
+        y: Y,
+        aux: Aux,
+        args: PyTree,
+        options: dict[str, Any],
+        state: _AndersonAccelFixedPointState,
+        tags: frozenset[object],
+        result: RESULTS,
+    ) -> tuple[Y, Aux, dict[str, Any]]:
+        return y, aux, {}
+
+
+AndersonAcceleration.__init__.__doc__ = """**Arguments:**
+
+- `rtol`: Relative tolerance for terminating the solve.
+- `atol`: Absolute tolerance for terminating the solve.
+- `norm`: The norm used to determine the difference between two iterates in the 
+    convergence criteria. Should be any function `PyTree -> Scalar`. Optimistix
+    includes three built-in norms: [`optimistix.max_norm`][],
+    [`optimistix.rms_norm`][], and [`optimistix.two_norm`][].
+- `mixing`: Beta coefficient for damping. Defaults to `1.`
+- `memory_size`: Number of vectors to keep in memory, both for past residuals
+    and past iterates. Defaults to `10`
+- `regularization: regularization factor to lift up the smallest e.v. of the
+    normal equations. Defaults to `1e-6`
+- `linear_solver: Solver from the [`lineax`][] library. Defaults to [`lx.LU()`][]
+"""

--- a/tests/test_fixed_point.py
+++ b/tests/test_fixed_point.py
@@ -5,6 +5,7 @@ import equinox as eqx
 import jax.numpy as jnp
 import jax.random as jr
 import jax.tree_util as jtu
+import lineax as lx
 import optimistix as optx
 import pytest
 from equinox.internal import ω
@@ -20,7 +21,13 @@ from .helpers import (
 
 
 atol = rtol = 1e-6
-_fp_solvers = (optx.FixedPointIteration(rtol, atol),)
+_fp_solvers = (
+    optx.FixedPointIteration(rtol, atol),
+    optx.AndersonAcceleration(
+        rtol, atol, mixing=0.5, linear_solver=lx.GMRES(1e-4, 1e-4)
+    ),
+    optx.AndersonAcceleration(rtol, atol, mixing=0.3),
+)
 smoke_aux = (jnp.ones((2, 3)), {"smoke_aux": jnp.ones(2)})
 
 


### PR DESCRIPTION
## New fixed point method: Anderson


Thank you very much for this amazing library.

I am attempting to implement the Anderson acceleration algorithm for fixed point systems, to contribute to solve #3.
So I would appreciate some advices on this PR, hoping that I did not miss any corner case.

### Description

**Goal**: solve $y^{\*}=f(y^{\*})$ with Anderson acceleration.

A step is performed by combining old residuals. We build a matrix $G$ containing columnwise the residuals at the `memory_size` last iterations.
We solve the minimization problem for $\alpha^{(k)}$:

$$
\begin{align}
  \min_{\alpha\in\mathbb{R}^d} & \|\|G\alpha^{(k)}\|\|_2^2\\
  \text{s.t.} & \sum_i \alpha_i^{(k)}
\end{align}
$$

This is equivalent to solve its KKT conditions system:

$$
\left[\begin{array}{cc}
  0 & \mathbb{1}^T\\
  \mathbb{1} & G^TG
\end{array}\right]
\left(\begin{array}{c}
  \nu^{(k)}\\
  \alpha^{(k)}
\end{array}\right) =
\left(\begin{array}{c}
  1\\
  \mathbb{0}
\end{array}\right)
$$

The user must thus provide a linear solver to compute $\alpha^{(k)}$.
Then we get as the update formula:

$$
y^{(k+1)} = \sum_{i\in\texttt{memory}} \alpha_i^{(k)}f(y^{(i)}).
$$

Adding some dampening to this dynamic looks like:

$$
y^{(k+1)} = (1-\beta)\sum_{i\in\texttt{memory}} \alpha_i^{(k)}y^{(i)} + \beta\sum_{i\in\texttt{memory}} \alpha_i^{(k)}f(y^{(i)}).
$$

So we keep a buffer with the past iterates $\left(y^{(i)}\right)_{i\in\texttt{memory}}$,

and residuals $\left(f(y^{(i)})-y^{(i)}\right)_{i\in\texttt{memory}}$.

---

### Some quick questions

1) Regarding the documentation, the `docs/requirements.txt` file is non-existant in the `dev` branch, I do not know if there is a good reason for that. Do I need to download it and push it in my PR?

2) In the linear solve for the anderson step, the `memory_size` first steps are not trivial to compute since the size of the system to solve changes... What I did is to make a "rank 1" memory with a `memory_size*dim` sized matrix of `memory_size` copies of the first iterate.
   My question is: could you think of another way of initializing the memory buffers? E.g.:
   - would initializing the residual buffer with all $+\infty$s, and the iterates buffer with $0$s be a good idea? Is `lineax` compatible with this somehow? In this case, the first iteration in the `init` function could be avoided by tracing with `jax.eval_shape`.
   - may I introduce `dim` new lines (and dual multipliers) to the system to force $(\alpha_i^{(k)})_{i\ge k}=0$?
This question comes from the fact that with what I implemented, the G^T G matrix at the few first iterations is ill-conditioned (rank k, with k the current iteration).

3) I am not sure of the best way to use the numpy context manager for dtype promotion. Is it costly to perform operations inside?

4) Do you know of some test case for which Anderson converges quickly while the fixed point solver should diverge? If you do, I may add it to the test suite to check my implementation.

---

### Some implementation details

I implemented the update formula with the dampening, with default "`mixing`" $\beta=\frac1{2}$, but also put a "`regularization`" on the system to help with the first few steps and last ones close to the solution (where $G\to 0$ as residuals get small), in the same spirit as Ridge for least square problems.

The solver is tested for $\beta=$`0.5` and $\beta=$`0.3`, in the same file as the fixed point solver, and for the same problems.