### PR TITLE
Tweak initial values to avoid a numerically pathological solve in our tests.

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -498,7 +498,7 @@ least_squares_fn_minima_init_args = (
     (
         rosenbrock,
         jnp.array(0.0),
-        (1.5 * jnp.ones((2, 4)), {"a": 1.5 * jnp.ones((2, 3, 2))}, ()),
+        (1.45 * jnp.ones((2, 4)), {"a": 1.45 * jnp.ones((2, 3, 2))}, ()),
         jnp.array(1.0),
     ),
     (simple_nn, jnp.array(0.0), ffn_dynamic, ffn_args),


### PR DESCRIPTION
This came up in https://github.com/patrick-kidger/optimistix/issues/160 and was followed up in https://github.com/google-deepmind/optax/issues/1412 and https://github.com/jax-ml/jax/issues/31473. 

I think overall - and barring any knowledge of XLA internals - I do find it believable that we're just happening to hit an edge case on a numerically challenging problem here. If we're getting one pretty bad value, Adam will keep around some of that for a long time. It does converge in even more steps from the same initial point. Increasing the second element of the initial values additionally causes `NelderMead` to fail, so it does seem like this is a Rosenbrock thing. (SGD always worked on this problem, so not using any historical values seems to help here.)

Overall though, I find it hard to judge if new internals now make XLA less numerically stable. Can you take a look at the JAX issue and let me know if you think this checks out, @patrick-kidger?