### PR TITLE
Golden search minimiser

### DIFF
--- a/docs/api/minimise.md
+++ b/docs/api/minimise.md
@@ -90,6 +90,11 @@ In addition to the following, note that the [Optax](https://github.com/deepmind/
 
 ---
 
+::: optimistix.GoldenSearch
+    options:
+        members:
+            - __init__
+
 ::: optimistix.BestSoFarMinimiser
     options:
         members:

--- a/optimistix/__init__.py
+++ b/optimistix/__init__.py
@@ -60,6 +60,7 @@ from ._solver import (
     FixedPointIteration as FixedPointIteration,
     fletcher_reeves as fletcher_reeves,
     GaussNewton as GaussNewton,
+    GoldenSearch as GoldenSearch,
     GradientDescent as GradientDescent,
     hestenes_stiefel as hestenes_stiefel,
     IndirectDampedNewtonDescent as IndirectDampedNewtonDescent,

--- a/optimistix/_solver/__init__.py
+++ b/optimistix/_solver/__init__.py
@@ -13,6 +13,7 @@ from .gauss_newton import (
     GaussNewton as GaussNewton,
     NewtonDescent as NewtonDescent,
 )
+from .golden import GoldenSearch as GoldenSearch
 from .gradient_methods import (
     AbstractGradientDescent as AbstractGradientDescent,
     GradientDescent as GradientDescent,

--- a/optimistix/_solver/golden.py
+++ b/optimistix/_solver/golden.py
@@ -176,6 +176,6 @@ class GoldenSearch(AbstractMinimiser[Scalar, Aux, _GoldenSearchState]):
 
 GoldenSearch.__init__.__doc__ = """**Arguments:**
 
-`rtol` - The relative tolerance for terminating the solve.
-`atol` - The absolute tolerance for terminating the solve.
+- `rtol`: The relative tolerance for terminating the solve.
+- `atol`: The absolute tolerance for terminating the solve.
 """

--- a/optimistix/_solver/golden.py
+++ b/optimistix/_solver/golden.py
@@ -28,22 +28,24 @@ class GoldenSearch(AbstractMinimiser[Scalar, Aux, _GoldenSearchState]):
     """Golden-section search for finding the minimum of a univariate function in a given
     interval.
 
+    This solver maintains a set of three reference points, defining the lower and upper
+    boundaries of the interval, as well as a midpoint chosen to divide the interval into
+    two sections by the golden ratio.
+    At each step, the reference points are updated by dropping one of the outer points
+    and updating the midpoint, such that the interval shrinks monotonously until the
+    solver has converged.
+
+    If the function is unimodal (has just one minimum inside the interval), then this
+    minimum is always found. If the function has several minima, then a local minimum is
+    identified, depending on the initial choice of interval.
+
     This solver requires the following `options`:
 
     - `lower`: The lower bound on the interval which contains the minimum.
     - `upper`: The upper bound on the interval which contains the minimum.
 
-    This algorithm considers the interval defined by `[lower, upper]` and two additional
-    points in between: a `middle` point, and a trial point. If the function value at the
-    trial point is lower than at the (previously evaluated) `middle` point, then the
-    trial point defines the new `middle` point, and the previous `middle` point defines
-    an outer point of the interval containing the minimum.
-    In this way, the interval containing the minimum is reduced by the golden ratio at
-    each step.
-
-    Note that the initial value `y0` is overwritten in the first step to guarantee that
-    the golden ratio is respected throughout. The minimum to be indentified is thus
-    defined only by the lower and upper bounds provided.
+    Note that the initial value `y0` is discarded in the first step to guarantee that
+    the golden ratio between interval segments is always maintained.
     """
 
     rtol: float

--- a/optimistix/_solver/golden.py
+++ b/optimistix/_solver/golden.py
@@ -1,0 +1,166 @@
+from collections.abc import Callable
+from typing import Any, ClassVar
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Bool, PyTree, Scalar
+
+from .._custom_types import Aux, Fn
+from .._minimise import AbstractMinimiser
+from .._misc import tree_where
+from .._solution import RESULTS
+
+
+class _Point(eqx.Module):
+    y: Scalar
+    f: Scalar
+
+
+class _GoldenSearchState(eqx.Module):
+    lower: _Point
+    middle: _Point
+    upper: _Point
+    first: Bool[Array, ""]
+
+
+class GoldenSearch(AbstractMinimiser[Scalar, Aux, _GoldenSearchState]):
+    """Golden-section search for finding the minimum of a univariate function in a given
+    interval.
+
+    This solver requires the following `options`:
+
+    - `lower`: The lower bound on the interval which contains the minimum.
+    - `upper`: The upper bound on the interval which contains the minimum.
+
+    This algorithm considers the interval defined by `[lower, upper]` and two additional
+    points in between: a `middle` point, and a trial point. If the function value at the
+    trial point is lower than at the (previously evaluated) `middle` point, then the
+    trial point defines the new `middle` point, and the previous `middle` point defines
+    an outer point of the interval containing the minimum.
+    In this way, the interval containing the minimum is reduced by the golden ratio at
+    each step.
+
+    Note that the initial value `y0` is overwritten in the first step to guarantee that
+    the golden ratio is respected throughout. The minimum to be indentified is thus
+    defined only by the lower and upper bounds provided.
+    """
+
+    rtol: float
+    atol: float
+    # All norms are the same for scalars.
+    norm: ClassVar[Callable[[PyTree], Scalar]] = jnp.abs
+
+    def init(
+        self,
+        fn: Fn[Scalar, Scalar, Aux],
+        y: Scalar,
+        args: PyTree,
+        options: dict[str, Any],
+        f_struct: jax.ShapeDtypeStruct,
+        aux_struct: PyTree[jax.ShapeDtypeStruct],
+        tags: frozenset[object],
+    ) -> _GoldenSearchState:
+        del aux_struct
+        lower = jnp.asarray(options["lower"], f_struct.dtype)
+        upper = jnp.asarray(options["upper"], f_struct.dtype)
+        if jnp.shape(y) != () or jnp.shape(lower) != () or jnp.shape(upper) != ():
+            raise ValueError(
+                "GoldenSearch can only be used to find the minimum of a function "
+                "taking a scalar input."
+            )
+        if not isinstance(f_struct, jax.ShapeDtypeStruct) or f_struct.shape != ():
+            raise ValueError(
+                "GoldenSearch can only be used to find the minimum of a function "
+                "producing a scalar output."
+            )
+
+        # Compute the first mddle point such that the golden ratio is respected.
+        # This divides the interval asymmetrically into components A and B, of
+        # length a and b, respectively. The ratio of their lengths, b / a, is equal
+        # to the golden ratio.
+        golden_ratio = (1 + jnp.sqrt(5)) / 2
+        middle = (upper - lower) / (golden_ratio + 1)
+
+        f_lower, _ = fn(lower, args)
+        f_middle, _ = fn(middle, args)
+        f_upper, _ = fn(upper, args)
+
+        jax.debug.print("lower: {}", (lower, f_lower))
+        jax.debug.print("middle: {}", (middle, f_middle))
+        jax.debug.print("upper: {}", (upper, f_upper))
+
+        return _GoldenSearchState(
+            lower=_Point(lower, f_lower),
+            middle=_Point(middle, f_middle),
+            upper=_Point(upper, f_upper),
+            first=jnp.array(True),
+        )
+
+    def step(
+        self,
+        fn: Fn[Scalar, Scalar, Aux],
+        y: Scalar,
+        args: PyTree,
+        options: dict[str, Any],
+        state: _GoldenSearchState,
+        tags: frozenset[object],
+    ) -> tuple[Scalar, _GoldenSearchState, Aux]:
+        jax.debug.print("")
+        # Safeguard to ensure that the first step respects the golden ratio rule.
+        y_ = jnp.where(state.first, state.lower.y + (state.upper.y - state.middle.y), y)
+        f, aux = fn(y_, args)
+
+        jax.debug.print("y_: {}", y_)
+        jax.debug.print("f: {}", f)
+
+        # y is either a new candidate minimum point, or an outer point defining
+        # the interval in which we may find the minimum.
+        is_min = f < state.middle.f
+        jax.debug.print("is_min: {}", is_min)
+        new_upper = tree_where(is_min, state.upper, _Point(y_, f))
+        new_lower = tree_where(is_min, state.middle, state.lower)
+        new_middle = tree_where(is_min, _Point(y_, f), state.middle)
+        jax.debug.print("new_lower: {}", new_lower.y)
+        jax.debug.print("new_upper: {}", new_upper.y)
+        jax.debug.print("new_middle: {}", new_middle.y)
+
+        new_y = new_lower.y + (new_upper.y - new_middle.y)
+        jax.debug.print("new_y: {}", new_y)
+        new_state = _GoldenSearchState(
+            lower=new_lower, middle=new_middle, upper=new_upper, first=jnp.array(False)
+        )
+
+        return new_y, new_state, aux
+
+    def terminate(
+        self,
+        fn: Fn[Scalar, Scalar, Aux],
+        y: Scalar,
+        args: PyTree,
+        options: dict[str, Any],
+        state: _GoldenSearchState,
+        tags: frozenset[object],
+    ) -> tuple[Bool[Array, ""], RESULTS]:
+        y_diff = y - state.middle.y  # This is always the smallest distance
+        jax.debug.print("y_diff: {}", y_diff)
+        # Note: currently avoiding computation of f_diff, to avoid calling it here
+        # + adding to compilation costs. These could easily be circumvented by writing
+        # the value of fn into the solver state. Taking the function values into account
+        # when checking convergence might make a difference, hence this is a TODO.
+
+        converged = jnp.abs(y_diff) < self.atol + self.rtol * jnp.abs(y)
+        return converged, RESULTS.successful
+
+    def postprocess(
+        self,
+        fn: Fn[Scalar, Scalar, Aux],
+        y: Scalar,
+        aux: Aux,
+        args: PyTree,
+        options: dict[str, Any],
+        state: _GoldenSearchState,
+        tags: frozenset[object],
+        result: RESULTS,
+    ) -> tuple[Scalar, Aux, dict[str, Any]]:
+        return y, aux, {}

--- a/optimistix/_solver/golden.py
+++ b/optimistix/_solver/golden.py
@@ -26,7 +26,8 @@ class _GoldenSearchState(eqx.Module):
 
 class GoldenSearch(AbstractMinimiser[Scalar, Aux, _GoldenSearchState]):
     """Golden-section search for finding the minimum of a univariate function in a given
-    interval.
+    interval. This solver does not use gradients and is not particularly fast, but it is
+    very robust.
 
     This solver maintains a set of three reference points, defining the lower and upper
     boundaries of the interval, as well as a midpoint chosen to divide the interval into
@@ -171,3 +172,10 @@ class GoldenSearch(AbstractMinimiser[Scalar, Aux, _GoldenSearchState]):
         result: RESULTS,
     ) -> tuple[Scalar, Aux, dict[str, Any]]:
         return y, aux, {}
+
+
+GoldenSearch.__init__.__doc__ = """**Arguments:**
+
+`rtol` - The relative tolerance for terminating the solve.
+`atol` - The absolute tolerance for terminating the solve.
+"""

--- a/optimistix/_solver/golden.py
+++ b/optimistix/_solver/golden.py
@@ -26,8 +26,8 @@ class _GoldenSearchState(eqx.Module):
 
 class GoldenSearch(AbstractMinimiser[Scalar, Aux, _GoldenSearchState]):
     """Golden-section search for finding the minimum of a univariate function in a given
-    interval. This solver does not use gradients and is not particularly fast, but it is
-    very robust.
+    interval. It does not use gradients and is not particularly fast, but it is very
+    robust.
 
     This solver maintains a set of three reference points, defining the lower and upper
     boundaries of the interval, as well as a midpoint chosen to divide the interval into

--- a/optimistix/_solver/golden.py
+++ b/optimistix/_solver/golden.py
@@ -37,7 +37,7 @@ class GoldenSearch(AbstractMinimiser[Scalar, Aux, _GoldenSearchState]):
 
     If the function is unimodal (has just one minimum inside the interval), then this
     minimum is always found. If the function has several minima, then a local minimum is
-    identified, depending on the initial choice of interval.
+    identified, depending on the initial choice of interval bounds.
 
     This solver requires the following `options`:
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -910,3 +910,13 @@ forward_only_fn_init_options_expected = (
         jnp.array(0.5),
     ),
 )
+
+
+golden_search_fn_y0_options_expected = (
+    (
+        lambda y, args: (y - 2)**2,
+        jnp.array(1),
+        dict(lower=0, upper=3),
+        jnp.array(2)
+    ),
+)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -913,5 +913,10 @@ forward_only_fn_init_options_expected = (
 
 
 golden_search_fn_y0_options_expected = (
-    (lambda y, args: (y - 2) ** 2, jnp.array(1), dict(lower=0, upper=3), jnp.array(2.)),
+    (
+        lambda y, args: (y - 2) ** 2,
+        jnp.array(1),
+        dict(lower=0, upper=3),
+        jnp.array(2.0),
+    ),
 )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -919,4 +919,20 @@ golden_search_fn_y0_options_expected = (
         dict(lower=0, upper=3),
         jnp.array(2.0),
     ),
+    # Edge case: minimum corresponds to lower bound
+    (lambda y, args: y**2, jnp.array(1), dict(lower=0, upper=3), jnp.array(0.0)),
+    # Edge case: minimum correspnds to upper bound
+    (
+        lambda y, args: (y - 2) ** 2,
+        jnp.array(1),
+        dict(lower=0, upper=2),
+        jnp.array(2.0),
+    ),
+    # Function unbounded below, can be minimised within bounds
+    (
+        lambda y, args: -((y - 2) ** 2),
+        jnp.array(1),
+        dict(lower=0, upper=3),
+        jnp.array(0.0),
+    ),
 )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -913,10 +913,5 @@ forward_only_fn_init_options_expected = (
 
 
 golden_search_fn_y0_options_expected = (
-    (
-        lambda y, args: (y - 2)**2,
-        jnp.array(1),
-        dict(lower=0, upper=3),
-        jnp.array(2)
-    ),
+    (lambda y, args: (y - 2) ** 2, jnp.array(1), dict(lower=0, upper=3), jnp.array(2.)),
 )

--- a/tests/test_minimise.py
+++ b/tests/test_minimise.py
@@ -214,12 +214,12 @@ def test_forward_minimisation(fn, y0, options, expected, solver):
         assert tree_allclose(sol.value, expected, atol=1e-4, rtol=1e-4)
 
 
-_golden = optx.GoldenSearch(rtol=1e-8, atol=1e-8)
+_golden = optx.GoldenSearch(rtol=1e-9, atol=1e-9)
 
 
 @pytest.mark.parametrize(
     "fn, y0, options, expected", golden_search_fn_y0_options_expected
 )
 def test_golden_search(fn, y0, options, expected):
-    sol = optx.minimise(fn, _golden, y0, options=options)
+    sol = optx.minimise(fn, _golden, y0, options=options, max_steps=2**9)
     assert tree_allclose(sol.value, expected)

--- a/tests/test_minimise.py
+++ b/tests/test_minimise.py
@@ -213,12 +213,11 @@ def test_forward_minimisation(fn, y0, options, expected, solver):
         assert sol.result == optx.RESULTS.successful
         assert tree_allclose(sol.value, expected, atol=1e-4, rtol=1e-4)
 
+_golden = optx.GoldenSearch(rtol=1e-8, atol=1e-8)
 
 @pytest.mark.parametrize(
     "fn, y0, options, expected", golden_search_fn_y0_options_expected
 )
 def test_golden_search(fn, y0, options, expected):
-    sol = optx.minimise(
-        fn, optx.GoldenSearch(rtol=1e-3, atol=1e-6), y0, options=options, max_steps=10
-    )
-    del sol
+    sol = optx.minimise(fn, _golden, y0, options=options)
+    assert tree_allclose(sol.value, expected)

--- a/tests/test_minimise.py
+++ b/tests/test_minimise.py
@@ -16,6 +16,7 @@ from .helpers import (
     bowl,
     finite_difference_jvp,
     forward_only_fn_init_options_expected,
+    golden_search_fn_y0_options_expected,
     matyas,
     minimisation_fn_minima_init_args,
     minimisers,
@@ -211,3 +212,13 @@ def test_forward_minimisation(fn, y0, options, expected, solver):
         sol = optx.minimise(fn, solver, y0, options=options, max_steps=2**10)
         assert sol.result == optx.RESULTS.successful
         assert tree_allclose(sol.value, expected, atol=1e-4, rtol=1e-4)
+
+
+@pytest.mark.parametrize(
+    "fn, y0, options, expected", golden_search_fn_y0_options_expected
+)
+def test_golden_search(fn, y0, options, expected):
+    sol = optx.minimise(
+        fn, optx.GoldenSearch(rtol=1e-3, atol=1e-6), y0, options=options, max_steps=10
+    )
+    del sol

--- a/tests/test_minimise.py
+++ b/tests/test_minimise.py
@@ -213,7 +213,9 @@ def test_forward_minimisation(fn, y0, options, expected, solver):
         assert sol.result == optx.RESULTS.successful
         assert tree_allclose(sol.value, expected, atol=1e-4, rtol=1e-4)
 
+
 _golden = optx.GoldenSearch(rtol=1e-8, atol=1e-8)
+
 
 @pytest.mark.parametrize(
     "fn, y0, options, expected", golden_search_fn_y0_options_expected


### PR DESCRIPTION
This is a simple minimisation routine that does not require gradient evaluation. Basically the minimisation cousin of `Bisection`, except that it keeps around three reference points and not two.

We use this as a subroutine in certain line searches for constrained optimisation.