### PR TITLE
Update docs (AbstractQuasiNewton class)

### DIFF
--- a/optimistix/_solver/quasi_newton.py
+++ b/optimistix/_solver/quasi_newton.py
@@ -114,7 +114,7 @@ class AbstractQuasiNewton(
 
     Alternative flavors of quasi-Newton approximations may be implemented by subclassing
     `AbstractQuasiNewton` and providing implementations for the abstract methods
-    `update_init` and `update_call`. The former is called to initialize the Hessian
+    `init_hessian` and `update_hessian`. The former is called to initialize the Hessian
     structure and the Hessian update state, while the latter is called to compute an
     update to the approximation of the Hessian or the inverse Hessian.
 


### PR DESCRIPTION
I’ve modified the names of the methods in the docstring `update_init` and `update_call` to `init_hessian` and `update_hessian`, respectively, to align with the names of two abstract methods.