### PR TITLE
fix typo

### DIFF
--- a/optimistix/_solver/backtracking.py
+++ b/optimistix/_solver/backtracking.py
@@ -35,17 +35,17 @@ class BacktrackingArmijo(AbstractSearch[Y, _FnInfo, _FnEvalInfo, _BacktrackingSt
             self.decrease_factor,
             (self.decrease_factor <= 0)  # pyright: ignore
             | (self.decrease_factor >= 1),  # pyright: ignore
-            "`BacktrackingArmoji(decrease_factor=...)` must be between 0 and 1.",
+            "`BacktrackingArmijo(decrease_factor=...)` must be between 0 and 1.",
         )
         self.slope = eqx.error_if(
             self.slope,
             (self.slope <= 0) | (self.slope >= 1),  # pyright: ignore
-            "`BacktrackingArmoji(slope=...)` must be between 0 and 1.",
+            "`BacktrackingArmijo(slope=...)` must be between 0 and 1.",
         )
         self.step_init = eqx.error_if(
             self.step_init,
             self.step_init <= 0,  # pyright: ignore
-            "`BacktrackingArmoji(step_init=...)` must be strictly greater than 0.",
+            "`BacktrackingArmijo(step_init=...)` must be strictly greater than 0.",
         )
 
     def init(self, y: Y, f_info_struct: _FnInfo) -> _BacktrackingState:


### PR DESCRIPTION
Hi, I've fixed typos in `BacktrackingArmijo` class docstrings.