### PR TITLE
add strong wolfe condition

### DIFF
--- a/optimistix/_solver/backtracking.py
+++ b/optimistix/_solver/backtracking.py
@@ -110,3 +110,112 @@ BacktrackingArmijo.__init__.__doc__ = """**Arguments:**
 - `step_init`: The first `step_size` the backtracking algorithm will
     try. Must be greater than 0.
 """
+
+
+class BacktrackingStrongWolfe(
+    AbstractSearch[Y, _FnInfo, _FnEvalInfo, _BacktrackingState]
+):
+    """Perform a backtracking line search satisfying the strong Wolfe conditions."""
+
+    decrease_factor: ScalarLike = 0.5
+    slope: ScalarLike = 1e-4
+    step_init: ScalarLike = 1.0
+    c: ScalarLike = 0.9
+
+    def __post_init__(self):
+        self.decrease_factor = eqx.error_if(
+            self.decrease_factor,
+            (self.decrease_factor <= 0)  # pyright: ignore
+            | (self.decrease_factor >= 1),  # pyright: ignore
+            "`BacktrackingStrongWolfe(decrease_factor=...)` must be between 0 and 1.",
+        )
+        self.slope = eqx.error_if(
+            self.slope,
+            (self.slope <= 0) | (self.slope >= 1),  # pyright: ignore
+            "`BacktrackingStrongWolfe(slope=...)` must be between 0 and 1.",
+        )
+        self.step_init = eqx.error_if(
+            self.step_init,
+            self.step_init <= 0,  # pyright: ignore
+            "`BacktrackingStrongWolfe(step_init=...)` must be strictly greater than 0.",
+        )
+        self.c = eqx.error_if(
+            self.c,
+            (self.c <= 0) | (self.c >= 1),  # pyright: ignore
+            "`BacktrackingStrongWolfe(c=...)` must be between 0 and 1.",
+        )
+
+    def init(self, y: Y, f_info_struct: _FnInfo) -> _BacktrackingState:
+        del y, f_info_struct
+        return _BacktrackingState(step_size=jnp.array(self.step_init))
+
+    def step(
+        self,
+        first_step: Bool[Array, ""],
+        y: Y,
+        y_eval: Y,
+        f_info: _FnInfo,
+        f_eval_info: _FnEvalInfo,
+        state: _BacktrackingState,
+    ) -> tuple[Scalar, Bool[Array, ""], RESULTS, _BacktrackingState]:
+        if not isinstance(
+            f_info,
+            (
+                FunctionInfo.EvalGrad,
+                FunctionInfo.EvalGradHessian,
+                FunctionInfo.EvalGradHessianInv,
+                FunctionInfo.ResidualJac,
+            ),
+        ) or not isinstance(
+            f_eval_info,
+            (
+                FunctionInfo.EvalGrad,
+                FunctionInfo.EvalGradHessian,
+                FunctionInfo.EvalGradHessianInv,
+                FunctionInfo.ResidualJac,
+            ),
+        ):
+            raise ValueError(
+                "Cannot use `BacktrackingStrongWolfe` with this solver. This is "
+                "because `BacktrackingStrongWolfe` requires gradients of the target "
+                "function, but this solver does not evaluate such gradients."
+            )
+
+        y_diff = (y_eval**ω - y**ω).ω
+        predicted_reduction = f_info.compute_grad_dot(y_diff)
+        # Terminate when the Armijo condition is satisfied. That is, `fn(y_eval)`
+        # must do better than its linear approximation:
+        # `fn(y_eval) < fn(y) + grad•y_diff`
+        f_min = f_info.as_min()
+        f_min_eval = f_eval_info.as_min()
+        f_min_diff = f_min_eval - f_min  # This number is probably negative
+        satisfies_armijo = f_min_diff <= self.slope * predicted_reduction
+        # curvature condition
+        decreases_sufficiently = jnp.abs(
+            f_eval_info.compute_grad_dot(y_diff)
+        ) <= self.c * jnp.abs(predicted_reduction)
+
+        accept = first_step | (satisfies_armijo & decreases_sufficiently)
+        step_size = jnp.where(
+            accept, self.step_init, self.decrease_factor * state.step_size
+        )
+        step_size = cast(Scalar, step_size)
+        return (
+            step_size,
+            accept,
+            RESULTS.successful,
+            _BacktrackingState(step_size=step_size),
+        )
+
+
+BacktrackingStrongWolfe.__init__.__doc__ = """**Arguments:**
+
+- `decrease_factor`: The rate at which to backtrack, i.e.
+    `next_stepsize = decrease_factor * current_stepsize`. Must be between 0 and 1.
+- `slope`: The slope of of the linear approximation to
+    `f` that the backtracking algorithm must exceed to terminate. Larger
+    means stricter termination criteria. Must be between 0 and 1.
+- `step_init`: The first `step_size` the backtracking algorithm will
+    try. Must be greater than 0.
+- `c`: The parameter for the strong Wolfe condition. Must be between 0 and 1.
+"""


### PR DESCRIPTION
Hi, I've implemented the strong Wolfe conditions for the backtracking line search. 

However, one potential issue related to the class of QuasiNewton's methods is that the sufficient decrease condition

$$|\nabla f(y_{k+1}) \cdot (y_{k+1} - y_k)| \le c | \nabla f(y_k) \cdot (y_{k+1} - y_k) |$$

requires $\nabla f(y_{k+1})$. Currently, the `step` method of the `AbstractQuasiNewton` class does not pass such information ([line 213--220](https://github.com/patrick-kidger/optimistix/blob/5b1fa3005993f4f098e9532de9d21e5513a6d550/optimistix/_solver/quasi_newton.py#L213C1-L220C10)): 

```python
step_size, accept, search_result, search_state = self.search.step(
            state.first_step,
            y,
            state.y_eval,
            state.f_info,
            FunctionInfo.Eval(f_eval),
            state.search_state,
        )
```


