### PR TITLE
Specify initial step size in `ClassicalTrustRegion`

### DIFF
--- a/optimistix/_solver/dogleg.py
+++ b/optimistix/_solver/dogleg.py
@@ -6,7 +6,7 @@ import jax.lax as lax
 import jax.numpy as jnp
 import lineax as lx
 from equinox.internal import ω
-from jaxtyping import Array, PyTree, Scalar
+from jaxtyping import Array, PyTree, Scalar, ScalarLike
 
 from .._custom_types import Aux, Out, Y
 from .._misc import (
@@ -246,6 +246,7 @@ class Dogleg(AbstractGaussNewton[Y, Out, Aux]):
         rtol: float,
         atol: float,
         norm: Callable[[PyTree], Scalar] = max_norm,
+        initial_radius: ScalarLike = 1.0,
         linear_solver: lx.AbstractLinearSolver = lx.AutoLinearSolver(well_posed=None),
         verbose: frozenset[str] = frozenset(),
     ):
@@ -256,7 +257,7 @@ class Dogleg(AbstractGaussNewton[Y, Out, Aux]):
         self.atol = atol
         self.norm = norm
         self.descent = DoglegDescent(linear_solver=linear_solver)
-        self.search = ClassicalTrustRegion()
+        self.search = ClassicalTrustRegion(initial_step_size=initial_radius)
         self.verbose = verbose
 
 
@@ -268,6 +269,9 @@ Dogleg.__init__.__doc__ = """**Arguments:**
     convergence criteria. Should be any function `PyTree -> Scalar`. Optimistix
     includes three built-in norms: [`optimistix.max_norm`][],
     [`optimistix.rms_norm`][], and [`optimistix.two_norm`][].
+- `initial_radius`: The trust-region radius used for the first
+    iteration. Controlling this parameter can be useful if there are initially
+    rejected iterations.
 - `linear_solver`: The linear solver used to compute the Newton part of the dogleg step.
 - `verbose`: Whether to print out extra information about how the solve is proceeding.
     Should be a frozenset of strings, specifying what information to print out. Valid

--- a/optimistix/_solver/levenberg_marquardt.py
+++ b/optimistix/_solver/levenberg_marquardt.py
@@ -283,6 +283,7 @@ class LevenbergMarquardt(AbstractGaussNewton[Y, Out, Aux]):
         rtol: float,
         atol: float,
         norm: Callable[[PyTree], Scalar] = max_norm,
+        initial_lambda: ScalarLike = 1.0,
         linear_solver: lx.AbstractLinearSolver = lx.QR(),
         verbose: frozenset[str] = frozenset(),
     ):
@@ -290,7 +291,7 @@ class LevenbergMarquardt(AbstractGaussNewton[Y, Out, Aux]):
         self.atol = atol
         self.norm = norm
         self.descent = DampedNewtonDescent(linear_solver=linear_solver)
-        self.search = ClassicalTrustRegion()
+        self.search = ClassicalTrustRegion(initial_step_size=1 / initial_lambda)
         self.verbose = verbose
 
 
@@ -302,6 +303,9 @@ LevenbergMarquardt.__init__.__doc__ = """**Arguments:**
     convergence criteria. Should be any function `PyTree -> Scalar`. Optimistix
     includes three built-in norms: [`optimistix.max_norm`][],
     [`optimistix.rms_norm`][], and [`optimistix.two_norm`][].
+- `initial_lambda`: The value of the Levenberg--Marquardt parameter used for the first
+    iteration. Controlling this parameter can be useful if there are initially rejected
+    iterations.
 - `linear_solver`: The linear solver to use to solve the damped Newton step. Defaults to
     `lineax.QR`.
 - `verbose`: Whether to print out extra information about how the solve is proceeding.
@@ -343,6 +347,7 @@ class IndirectLevenbergMarquardt(AbstractGaussNewton[Y, Out, Aux]):
         atol: float,
         norm: Callable[[PyTree], Scalar] = max_norm,
         lambda_0: ScalarLike = 1.0,
+        initial_radius: ScalarLike = 1.0,
         linear_solver: lx.AbstractLinearSolver = lx.AutoLinearSolver(well_posed=False),
         root_finder: AbstractRootFinder = Newton(rtol=0.01, atol=0.01),
         verbose: frozenset[str] = frozenset(),
@@ -355,7 +360,7 @@ class IndirectLevenbergMarquardt(AbstractGaussNewton[Y, Out, Aux]):
             linear_solver=linear_solver,
             root_finder=root_finder,
         )
-        self.search = ClassicalTrustRegion()
+        self.search = ClassicalTrustRegion(initial_step_size=initial_radius)
         self.verbose = verbose
 
 
@@ -370,6 +375,9 @@ IndirectLevenbergMarquardt.__init__.__doc__ = """**Arguments:**
 - `lambda_0`: The initial value of the Levenberg--Marquardt parameter used in the root-
     find to hit the trust-region radius. If `IndirectLevenbergMarquardt` is failing,
     this value may need to be increased.
+- `initial_radius`: The trust-region radius used for the first
+    iteration. Controlling this parameter can be useful if there are initially
+    rejected iterations.
 - `linear_solver`: The linear solver used to compute the Newton step.
 - `root_finder`: The root finder used to find the Levenberg--Marquardt parameter which
     hits the trust-region radius.

--- a/optimistix/_solver/trust_region.py
+++ b/optimistix/_solver/trust_region.py
@@ -47,6 +47,8 @@ class _AbstractTrustRegion(AbstractSearch[Y, _FnInfo, _FnEvalInfo, _TrustRegionS
     high_constant: AbstractVar[ScalarLike]
     low_constant: AbstractVar[ScalarLike]
 
+    initial_step_size: AbstractVar[ScalarLike]
+
     def __post_init__(self):
         # You would not expect `self.low_cutoff` or `self.high_cutoff` to
         # be below zero, but this is technically not incorrect so we don't
@@ -72,7 +74,7 @@ class _AbstractTrustRegion(AbstractSearch[Y, _FnInfo, _FnEvalInfo, _TrustRegionS
 
     def init(self, y: Y, f_info_struct: _FnInfo) -> _TrustRegionState:
         del f_info_struct
-        return _TrustRegionState(step_size=jnp.array(1.0))
+        return _TrustRegionState(step_size=jnp.array(self.initial_step_size))
 
     def step(
         self,
@@ -126,6 +128,8 @@ class ClassicalTrustRegion(
     low_cutoff: ScalarLike = 0.01
     high_constant: ScalarLike = 3.5
     low_constant: ScalarLike = 0.25
+
+    initial_step_size: ScalarLike = 1.0
 
     def predict_reduction(
         self,
@@ -222,13 +226,17 @@ class LinearTrustRegion(
     high_constant: ScalarLike = 3.5
     low_constant: ScalarLike = 0.25
 
+    initial_step_size: ScalarLike = 1.0
+
     def predict_reduction(
         self,
         y_diff: Y,
-        f_info: FunctionInfo.EvalGrad
-        | FunctionInfo.EvalGradHessian
-        | FunctionInfo.EvalGradHessianInv
-        | FunctionInfo.ResidualJac,
+        f_info: (
+            FunctionInfo.EvalGrad
+            | FunctionInfo.EvalGradHessian
+            | FunctionInfo.EvalGradHessianInv
+            | FunctionInfo.ResidualJac
+        ),
     ) -> Scalar:
         """Compute the expected decrease in loss from taking the step `y_diff`.
 
@@ -283,6 +291,7 @@ and decrease the step-size on the next iteration.
 high_constant`.
 - `low_constant`: when `ratio < low_cutoff`, multiply the previous step-size by
 low_constant`.
+- `initial_step_size`: the step size used for the first iteration. Defaults to `1.0`.
 """
 
 LinearTrustRegion.__init__.__doc__ = _init_doc


### PR DESCRIPTION
See discussion in #187 about specifying an initial step size in the `ClassicalTrustRegion`. I've added the corresponding parameters to `Dogleg`, `LevenbergMarquardt`, and `IndirectLevenbergMarquardt`, and I've named things according to the language used in the docstrings.