### PR TITLE
Add callback functionality to solvers that use `verbose_print`.

### DIFF
--- a/optimistix/_solver/gauss_newton.py
+++ b/optimistix/_solver/gauss_newton.py
@@ -211,6 +211,7 @@ class AbstractGaussNewton(AbstractLeastSquaresSolver[Y, Out, Aux, _GaussNewtonSt
         AbstractSearch[Y, FunctionInfo.ResidualJac, FunctionInfo.ResidualJac, Any]
     ]
     verbose: AbstractVar[frozenset[str]]
+    verbose_callback: Callable[..., None] = verbose_print
 
     def init(
         self,
@@ -302,7 +303,7 @@ class AbstractGaussNewton(AbstractLeastSquaresSolver[Y, Out, Aux, _GaussNewtonSt
             verbose_y = "y" in self.verbose
             loss_eval = 0.5 * sum_squares(f_eval_info.residual)
             loss = 0.5 * sum_squares(state.f_info.residual)
-            verbose_print(
+            self.verbose_callback(
                 (verbose_step, "Step", state.num_steps),
                 (
                     verbose_step and verbose_accepted,

--- a/optimistix/_solver/optax.py
+++ b/optimistix/_solver/optax.py
@@ -30,6 +30,7 @@ class OptaxMinimiser(AbstractMinimiser[Y, Aux, _OptaxState]):
     atol: float
     norm: Callable[[PyTree], Scalar]
     verbose: frozenset[str]
+    verbose_callback: Callable[..., None] = verbose_print
 
     def __init__(
         self,
@@ -92,7 +93,7 @@ class OptaxMinimiser(AbstractMinimiser[Y, Aux, _OptaxState]):
         (f, aux), grads = eqx.filter_value_and_grad(fn, has_aux=True)(y, args)
         f = cast(Array, f)
         if len(self.verbose) > 0:
-            verbose_print(
+            self.verbose_callback(
                 ("step" in self.verbose, "Step", state.step),
                 ("loss" in self.verbose, "Loss", f),
                 ("y" in self.verbose, "y", y),

--- a/optimistix/_solver/quasi_newton.py
+++ b/optimistix/_solver/quasi_newton.py
@@ -138,6 +138,8 @@ class AbstractQuasiNewton(
     search: AbstractVar[AbstractSearch[Y, _Hessian, FunctionInfo.Eval, Any]]
     verbose: AbstractVar[frozenset[str]]
 
+    verbose_callback: Callable[..., None] = verbose_print
+
     @abc.abstractmethod
     def init_hessian(
         self, y: Y, f: Scalar, grad: Y
@@ -272,7 +274,7 @@ class AbstractQuasiNewton(
             verbose_y = "y" in self.verbose
             loss_eval = f_eval
             loss = state.f_info.f
-            verbose_print(
+            self.verbose_callback(
                 (verbose_loss, "Loss on this step", loss_eval),
                 (verbose_loss, "Loss on the last accepted step", loss),
                 (verbose_step_size, "Step size", step_size),

--- a/tests/test_verbose.py
+++ b/tests/test_verbose.py
@@ -1,0 +1,117 @@
+from collections import deque
+from typing import Any
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import optax
+import optimistix as optx
+import pytest
+
+
+@pytest.fixture
+def setup_callback():
+    memory = deque()
+
+    def callback(*args: tuple[bool, str, Any]):
+        jax.debug.callback(memory.append, args)
+
+    return memory, callback
+
+
+@pytest.fixture
+def test_fn():
+    @eqx.filter_jit
+    def fn(y, args):
+        out = y
+        aux = None
+        return out, aux
+
+    y = jnp.array(0.0)
+    args = None
+    f_struct = jax.ShapeDtypeStruct((), jnp.float64)
+    aux_struct = None
+    tags = frozenset()
+    options = {}
+
+    return fn, (y, args, f_struct, aux_struct, tags, options)
+
+
+def test_verbose_callback_gauss_newton(setup_callback, test_fn):
+    memory, callback = setup_callback
+
+    class SolverWithCallback(optx.GaussNewton):
+        verbose_callback = callback
+
+    callback_solver = SolverWithCallback(
+        rtol=1e-6,
+        atol=1e-6,
+        verbose=frozenset({"step", "loss", "y"}),
+    )
+
+    fn, (y, args, f_struct, aux_struct, tags, options) = test_fn
+
+    state = callback_solver.init(fn, y, args, options, f_struct, aux_struct, tags)
+
+    callback_solver.step(fn, y, args, options, state, tags)
+
+    assert len(memory) == 1
+
+    entry = memory.pop()
+
+    assert (jnp.array(True), "Step", jnp.array(0)) in entry
+    assert (jnp.array(True), "Loss on this step", jnp.array(0.0)) in entry
+    assert (jnp.array(True), "y", jnp.array(0.0)) in entry
+
+
+def test_verbose_callback_lbfgs(setup_callback, test_fn):
+    memory, callback = setup_callback
+
+    class SolverWithCallback(optx.LBFGS):
+        verbose_callback = callback
+
+    callback_solver = SolverWithCallback(
+        rtol=1e-6,
+        atol=1e-6,
+        verbose=frozenset({"loss", "y"}),
+    )
+
+    fn, (y, args, f_struct, aux_struct, tags, options) = test_fn
+
+    state = callback_solver.init(fn, y, args, options, f_struct, aux_struct, tags)
+
+    callback_solver.step(fn, y, args, options, state, tags)
+
+    assert len(memory) == 1
+
+    entry = memory.pop()
+
+    assert (jnp.array(True), "Loss on this step", jnp.array(0.0)) in entry
+    assert (jnp.array(True), "y", jnp.array(0.0)) in entry
+
+
+def test_verbose_callback_optax(setup_callback, test_fn):
+    memory, callback = setup_callback
+
+    class SolverWithCallback(optx.OptaxMinimiser):
+        verbose_callback = callback
+
+    callback_solver = SolverWithCallback(
+        rtol=1e-6,
+        atol=1e-6,
+        verbose=frozenset({"loss", "y"}),
+        optim=optax.sgd(learning_rate=3e-3),
+    )
+
+    fn, (y, args, f_struct, aux_struct, tags, options) = test_fn
+
+    state = callback_solver.init(fn, y, args, options, f_struct, aux_struct, tags)
+
+    callback_solver.step(fn, y, args, options, state, tags)
+
+    assert len(memory) == 1
+
+    entry = memory.pop()
+    assert (jnp.array(False), "Step", jnp.array(0)) in entry
+    assert (jnp.array(True), "Loss", jnp.array(0.0)) in entry
+    assert (jnp.array(True), "y", jnp.array(0.0)) in entry


### PR DESCRIPTION
We currently have a complicated home-brewed set of optimizers and we'd like to switch to using optimistix for all the usual reasons. However we have need to analyze and log fit dynamics captured using methods such as `jax.debug.callback` as part of our development of internal fitting routines. 

In this PR I have added a new class variable `verbose_callback` to the optimistix classes that utilize `_misc.verbose_print`. This allows end users to override the `verbose_print` behaviour to implement arbitrary callbacks with `jax.debug.callback` such as dumping progress to logs, memory etc...

The justification for overriding `verbose_print` is that consideration has already been taken as to what data is considered appropriate to pass to a jax callback and an API for customizing what data to pass is already in place. 

Classes impacted are `OptaxMinimizer` `AbstractGaussNewton` and `AbstractQuasiNewton`. The default callback remains `verbose_print` and unless a child class explicitly overrides this class variable their behaviour remains the same.

A pattern for a simple use case is demonstrated in the `test_verbose.py` unit test.