### PR TITLE
Support true second order methods

### DIFF
--- a/benchmarks/iter_count.py
+++ b/benchmarks/iter_count.py
@@ -2,6 +2,7 @@
 
 import sys
 
+
 sys.path.insert(0, "/home/user/optimistix")
 
 import jax
@@ -11,6 +12,7 @@ import jax.random as jr
 import jax.tree_util as jtu
 import lineax as lx
 import optimistix as optx
+
 
 jax.config.update("jax_enable_x64", True)
 
@@ -59,13 +61,37 @@ matrix = jr.normal(key, (flat_bowl.size, flat_bowl.size))
 bowl_args = matrix.T @ matrix
 
 minimisation_problems = [
-    ("bowl",          bowl,          bowl_init,                    bowl_args,                         True),
-    ("matyas",        matyas,        [jnp.array(6.0), jnp.array(6.0)], (jnp.array(0.26), jnp.array(0.48)), True),
-    ("beale",         beale,         [jnp.array(2.0), jnp.array(0.0)], (jnp.array(1.5), jnp.array(2.25), jnp.array(2.625)), False),
-    ("himmelblau",    _himmelblau,   [jnp.array(2.0), jnp.array(2.5)], (jnp.array(11.0), jnp.array(7.0)),  False),
-    ("sq_minus_one",  square_minus_one, jnp.array(1.0),            None,                              True),
-    ("glob_convex",   globally_convex,  jnp.array([0.4, -0.3, 0.2]),  jnp.ones(3),                   True),
-    ("glob_convex_far", globally_convex, jnp.array([10.0, -8.0, 6.0]), jnp.ones(3),                  True),
+    ("bowl", bowl, bowl_init, bowl_args, True),
+    (
+        "matyas",
+        matyas,
+        [jnp.array(6.0), jnp.array(6.0)],
+        (jnp.array(0.26), jnp.array(0.48)),
+        True,
+    ),
+    (
+        "beale",
+        beale,
+        [jnp.array(2.0), jnp.array(0.0)],
+        (jnp.array(1.5), jnp.array(2.25), jnp.array(2.625)),
+        False,
+    ),
+    (
+        "himmelblau",
+        _himmelblau,
+        [jnp.array(2.0), jnp.array(2.5)],
+        (jnp.array(11.0), jnp.array(7.0)),
+        False,
+    ),
+    ("sq_minus_one", square_minus_one, jnp.array(1.0), None, True),
+    ("glob_convex", globally_convex, jnp.array([0.4, -0.3, 0.2]), jnp.ones(3), True),
+    (
+        "glob_convex_far",
+        globally_convex,
+        jnp.array([10.0, -8.0, 6.0]),
+        jnp.ones(3),
+        True,
+    ),
 ]
 
 # ---------------------------------------------------------------------------
@@ -94,9 +120,9 @@ rosenbrock_init1 = [jnp.array(0.5), jnp.array(0.4)]
 rosenbrock_init2 = [jnp.array(-0.5), jnp.array(0.1)]
 
 least_squares_problems = [
-    ("diag_bowl",    diagonal_quadratic_bowl, diagonal_bowl_init, diagonal_bowl_args),
-    ("rosenbrock_a", rosenbrock,              rosenbrock_init1,   jnp.array(1.0)),
-    ("rosenbrock_b", rosenbrock,              rosenbrock_init2,   jnp.array(1.0)),
+    ("diag_bowl", diagonal_quadratic_bowl, diagonal_bowl_init, diagonal_bowl_args),
+    ("rosenbrock_a", rosenbrock, rosenbrock_init1, jnp.array(1.0)),
+    ("rosenbrock_b", rosenbrock, rosenbrock_init2, jnp.array(1.0)),
 ]
 
 # ---------------------------------------------------------------------------
@@ -104,26 +130,42 @@ least_squares_problems = [
 # ---------------------------------------------------------------------------
 
 minimise_solvers = [
-    ("LineSearchNewton(Cholesky)",  optx.LineSearchNewton(rtol, atol)),
-    ("LineSearchNewton(CG)",        optx.LineSearchNewton(rtol, atol, linear_solver=lx.CG(rtol=1e-6, atol=0.0))),
-    ("LineSearchNewton(TruncCG)",   optx.LineSearchNewton(rtol, atol, linear_solver=optx.TruncatedCG(rtol=0.5, atol=0.0))),
-    ("TrustNewton(Cholesky)",       optx.TrustNewton(rtol, atol)),
-    ("TrustNewton(CG)",             optx.TrustNewton(rtol, atol, linear_solver=lx.CG(rtol=1e-6, atol=0.0))),
-    ("TrustNewton(Steihaug)",       optx.TrustNewton(rtol, atol, use_steihaug=True)),
-    ("BFGS",                        optx.BFGS(rtol, atol, use_inverse=False)),
-    ("LBFGS",                       optx.LBFGS(rtol, atol, use_inverse=False)),
-    ("GradientDescent",             optx.GradientDescent(1.5e-2, rtol, atol)),
+    ("LineSearchNewton(Cholesky)", optx.LineSearchNewton(rtol, atol)),
+    (
+        "LineSearchNewton(CG)",
+        optx.LineSearchNewton(rtol, atol, linear_solver=lx.CG(rtol=1e-6, atol=0.0)),
+    ),
+    (
+        "LineSearchNewton(TruncCG)",
+        optx.LineSearchNewton(
+            rtol, atol, linear_solver=optx.TruncatedCG(rtol=0.5, atol=0.0)
+        ),
+    ),
+    ("TrustNewton(Cholesky)", optx.TrustNewton(rtol, atol)),
+    (
+        "TrustNewton(CG)",
+        optx.TrustNewton(rtol, atol, linear_solver=lx.CG(rtol=1e-6, atol=0.0)),
+    ),
+    ("TrustNewton(Steihaug)", optx.TrustNewton(rtol, atol, use_steihaug=True)),
+    ("BFGS", optx.BFGS(rtol, atol, use_inverse=False)),
+    ("LBFGS", optx.LBFGS(rtol, atol, use_inverse=False)),
+    ("GradientDescent", optx.GradientDescent(1.5e-2, rtol, atol)),
 ]
 
 least_squares_solvers = [
-    ("LineSearchNewton(Cholesky)",  optx.LineSearchNewton(rtol, atol)),
-    ("TrustNewton(Cholesky)",       optx.TrustNewton(rtol, atol)),
-    ("TrustNewton(Steihaug)",       optx.TrustNewton(rtol, atol, use_steihaug=True)),
-    ("GaussNewton",                 optx.GaussNewton(rtol, atol, linear_solver=lx.AutoLinearSolver(well_posed=False))),
-    ("LevenbergMarquardt",          optx.LevenbergMarquardt(rtol, atol)),
-    ("IndirectLevenbergMarquardt",  optx.IndirectLevenbergMarquardt(rtol, atol)),
-    ("BFGS",                        optx.BFGS(rtol, atol, use_inverse=False)),
-    ("LBFGS",                       optx.LBFGS(rtol, atol, use_inverse=False)),
+    ("LineSearchNewton(Cholesky)", optx.LineSearchNewton(rtol, atol)),
+    ("TrustNewton(Cholesky)", optx.TrustNewton(rtol, atol)),
+    ("TrustNewton(Steihaug)", optx.TrustNewton(rtol, atol, use_steihaug=True)),
+    (
+        "GaussNewton",
+        optx.GaussNewton(
+            rtol, atol, linear_solver=lx.AutoLinearSolver(well_posed=False)
+        ),
+    ),
+    ("LevenbergMarquardt", optx.LevenbergMarquardt(rtol, atol)),
+    ("IndirectLevenbergMarquardt", optx.IndirectLevenbergMarquardt(rtol, atol)),
+    ("BFGS", optx.BFGS(rtol, atol, use_inverse=False)),
+    ("LBFGS", optx.LBFGS(rtol, atol, use_inverse=False)),
 ]
 
 # ---------------------------------------------------------------------------
@@ -136,8 +178,9 @@ SPD_FNS = {bowl, matyas, square_minus_one, globally_convex}
 def run_minimise(solver, fn, init, args, is_spd):
     tags = frozenset({lx.positive_semidefinite_tag}) if is_spd else frozenset()
     max_steps = 100_000 if isinstance(solver, optx.GradientDescent) else 10_000
-    sol = optx.minimise(fn, solver, init, args=args, max_steps=max_steps,
-                        throw=False, tags=tags)
+    sol = optx.minimise(
+        fn, solver, init, args=args, max_steps=max_steps, throw=False, tags=tags
+    )
     return int(sol.stats["num_steps"]), sol.result == optx.RESULTS.successful
 
 
@@ -158,7 +201,9 @@ def print_table(title, solvers, problems, runner):
     col_w = max(max(len(s) for s in solver_names), 6) + 2
     prob_w = [max(len(p), 6) + 2 for p in prob_names]
 
-    header = f"{'Solver':<{col_w}}" + "".join(f"{p:>{w}}" for p, w in zip(prob_names, prob_w))
+    header = f"{'Solver':<{col_w}}" + "".join(
+        f"{p:>{w}}" for p, w in zip(prob_names, prob_w)
+    )
     sep = "-" * len(header)
 
     print(f"\n{'=' * len(header)}")
@@ -174,11 +219,11 @@ def print_table(title, solvers, problems, runner):
             try:
                 n, ok = runner(solver, *prob_args)
                 row += f"{fmt(n, ok):>{prob_w_i}}"
-            except Exception as e:
+            except Exception:
                 row += f"{'ERR':>{prob_w_i}}"
         print(row)
 
-    print(f"\n  ! = did not converge (result != successful)")
+    print("\n  ! = did not converge (result != successful)")
 
 
 print_table(

--- a/benchmarks/iter_count.py
+++ b/benchmarks/iter_count.py
@@ -1,0 +1,196 @@
+"""Compare iteration counts across solvers on the standard test problems."""
+
+import sys
+
+sys.path.insert(0, "/home/user/optimistix")
+
+import jax
+import jax.flatten_util as jfu
+import jax.numpy as jnp
+import jax.random as jr
+import jax.tree_util as jtu
+import lineax as lx
+import optimistix as optx
+
+jax.config.update("jax_enable_x64", True)
+
+rtol = atol = 1e-4
+
+# ---------------------------------------------------------------------------
+# Problems
+# ---------------------------------------------------------------------------
+
+
+def bowl(tree, args):
+    flat, _ = jfu.ravel_pytree(tree)
+    return flat @ args @ flat
+
+
+def matyas(tree, args):
+    x, y = tree
+    a, b = args
+    return a * (x**2 + y**2) - b * x * y
+
+
+def beale(tree, args):
+    x, y = tree
+    a, b, c = args
+    return (a - x + x * y) ** 2 + (b - x + x * y**2) ** 2 + (c - x + x * y**3) ** 2
+
+
+def square_minus_one(x, args):
+    return jnp.sum(jnp.square(x)) - 1.0
+
+
+def globally_convex(y, scale):
+    return jnp.sum(jnp.cosh(scale * y) - 1)
+
+
+def _himmelblau(tree, args):
+    x, y = tree
+    a, b = args
+    return (x**2 + y - a) ** 2 + (x + y**2 - b) ** 2
+
+
+key = jr.PRNGKey(17)
+bowl_init = ({"a": 0.05 * jnp.ones((2, 3, 3))}, (0.05 * jnp.ones(2)))
+flat_bowl, _ = jfu.ravel_pytree(bowl_init)
+matrix = jr.normal(key, (flat_bowl.size, flat_bowl.size))
+bowl_args = matrix.T @ matrix
+
+minimisation_problems = [
+    ("bowl",          bowl,          bowl_init,                    bowl_args,                         True),
+    ("matyas",        matyas,        [jnp.array(6.0), jnp.array(6.0)], (jnp.array(0.26), jnp.array(0.48)), True),
+    ("beale",         beale,         [jnp.array(2.0), jnp.array(0.0)], (jnp.array(1.5), jnp.array(2.25), jnp.array(2.625)), False),
+    ("himmelblau",    _himmelblau,   [jnp.array(2.0), jnp.array(2.5)], (jnp.array(11.0), jnp.array(7.0)),  False),
+    ("sq_minus_one",  square_minus_one, jnp.array(1.0),            None,                              True),
+    ("glob_convex",   globally_convex,  jnp.array([0.4, -0.3, 0.2]),  jnp.ones(3),                   True),
+    ("glob_convex_far", globally_convex, jnp.array([10.0, -8.0, 6.0]), jnp.ones(3),                  True),
+]
+
+# ---------------------------------------------------------------------------
+# Least-squares problems
+# ---------------------------------------------------------------------------
+
+
+def diagonal_quadratic_bowl(tree, args):
+    return jtu.tree_map(lambda x, w: jnp.square(x) * (0.1 + w), tree, args)
+
+
+diagonal_bowl_init = ({"a": 0.05 * jnp.ones((2, 3, 3))}, (0.05 * jnp.ones(2)))
+leaves, treedef = jtu.tree_flatten(diagonal_bowl_init)
+diagonal_bowl_args = treedef.unflatten(
+    [jr.normal(key, leaf.shape, leaf.dtype) ** 2 for leaf in leaves]
+)
+
+
+def rosenbrock(tree, args):
+    x, y = tree
+    scale = args
+    return jnp.array([10 * (y - x**2), scale * (1 - x)])
+
+
+rosenbrock_init1 = [jnp.array(0.5), jnp.array(0.4)]
+rosenbrock_init2 = [jnp.array(-0.5), jnp.array(0.1)]
+
+least_squares_problems = [
+    ("diag_bowl",    diagonal_quadratic_bowl, diagonal_bowl_init, diagonal_bowl_args),
+    ("rosenbrock_a", rosenbrock,              rosenbrock_init1,   jnp.array(1.0)),
+    ("rosenbrock_b", rosenbrock,              rosenbrock_init2,   jnp.array(1.0)),
+]
+
+# ---------------------------------------------------------------------------
+# Solvers
+# ---------------------------------------------------------------------------
+
+minimise_solvers = [
+    ("LineSearchNewton(Cholesky)",  optx.LineSearchNewton(rtol, atol)),
+    ("LineSearchNewton(CG)",        optx.LineSearchNewton(rtol, atol, linear_solver=lx.CG(rtol=1e-6, atol=0.0))),
+    ("LineSearchNewton(TruncCG)",   optx.LineSearchNewton(rtol, atol, linear_solver=optx.TruncatedCG(rtol=0.5, atol=0.0))),
+    ("TrustNewton(Cholesky)",       optx.TrustNewton(rtol, atol)),
+    ("TrustNewton(CG)",             optx.TrustNewton(rtol, atol, linear_solver=lx.CG(rtol=1e-6, atol=0.0))),
+    ("TrustNewton(Steihaug)",       optx.TrustNewton(rtol, atol, use_steihaug=True)),
+    ("BFGS",                        optx.BFGS(rtol, atol, use_inverse=False)),
+    ("LBFGS",                       optx.LBFGS(rtol, atol, use_inverse=False)),
+    ("GradientDescent",             optx.GradientDescent(1.5e-2, rtol, atol)),
+]
+
+least_squares_solvers = [
+    ("LineSearchNewton(Cholesky)",  optx.LineSearchNewton(rtol, atol)),
+    ("TrustNewton(Cholesky)",       optx.TrustNewton(rtol, atol)),
+    ("TrustNewton(Steihaug)",       optx.TrustNewton(rtol, atol, use_steihaug=True)),
+    ("GaussNewton",                 optx.GaussNewton(rtol, atol, linear_solver=lx.AutoLinearSolver(well_posed=False))),
+    ("LevenbergMarquardt",          optx.LevenbergMarquardt(rtol, atol)),
+    ("IndirectLevenbergMarquardt",  optx.IndirectLevenbergMarquardt(rtol, atol)),
+    ("BFGS",                        optx.BFGS(rtol, atol, use_inverse=False)),
+    ("LBFGS",                       optx.LBFGS(rtol, atol, use_inverse=False)),
+]
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+SPD_FNS = {bowl, matyas, square_minus_one, globally_convex}
+
+
+def run_minimise(solver, fn, init, args, is_spd):
+    tags = frozenset({lx.positive_semidefinite_tag}) if is_spd else frozenset()
+    max_steps = 100_000 if isinstance(solver, optx.GradientDescent) else 10_000
+    sol = optx.minimise(fn, solver, init, args=args, max_steps=max_steps,
+                        throw=False, tags=tags)
+    return int(sol.stats["num_steps"]), sol.result == optx.RESULTS.successful
+
+
+def run_least_squares(solver, fn, init, args):
+    sol = optx.least_squares(fn, solver, init, args=args, max_steps=10_000, throw=False)
+    return int(sol.stats["num_steps"]), sol.result == optx.RESULTS.successful
+
+
+def fmt(n, ok):
+    mark = "" if ok else "!"
+    return f"{n}{mark}"
+
+
+def print_table(title, solvers, problems, runner):
+    solver_names = [s for s, _ in solvers]
+    prob_names = [p[0] for p in problems]
+
+    col_w = max(max(len(s) for s in solver_names), 6) + 2
+    prob_w = [max(len(p), 6) + 2 for p in prob_names]
+
+    header = f"{'Solver':<{col_w}}" + "".join(f"{p:>{w}}" for p, w in zip(prob_names, prob_w))
+    sep = "-" * len(header)
+
+    print(f"\n{'=' * len(header)}")
+    print(title)
+    print(f"{'=' * len(header)}")
+    print(header)
+    print(sep)
+
+    for sname, solver in solvers:
+        row = f"{sname:<{col_w}}"
+        for prob, prob_w_i in zip(problems, prob_w):
+            prob_args = prob[1:]  # fn, init, args[, is_spd]
+            try:
+                n, ok = runner(solver, *prob_args)
+                row += f"{fmt(n, ok):>{prob_w_i}}"
+            except Exception as e:
+                row += f"{'ERR':>{prob_w_i}}"
+        print(row)
+
+    print(f"\n  ! = did not converge (result != successful)")
+
+
+print_table(
+    "MINIMISE  — iterations (! = did not converge)",
+    minimise_solvers,
+    minimisation_problems,
+    lambda solver, fn, init, args, is_spd: run_minimise(solver, fn, init, args, is_spd),
+)
+
+print_table(
+    "LEAST SQUARES  — iterations (! = did not converge)",
+    least_squares_solvers,
+    least_squares_problems,
+    lambda solver, fn, init, args: run_least_squares(solver, fn, init, args),
+)

--- a/benchmarks/levenberg-marquardt.py
+++ b/benchmarks/levenberg-marquardt.py
@@ -41,7 +41,6 @@ import diffrax as dfx  # pyright: ignore
 import equinox as eqx
 import jax
 import jax.numpy as jnp
-import jax.scipy as jsp
 import jaxopt  # pyright: ignore
 import lineax as lx
 import optimistix as optx
@@ -107,40 +106,6 @@ def residuals(parameters, y0s__values):
     return values - pred_values
 
 
-# Lineax deliberately doesn't offer this as a solver.
-# It's mostly just a worse version of QR. It runs at similar speed empirically (see the
-# benchmarks below), but is substantially less accurate.
-# Anyway, we have an implementation here to provide a fair comparison with JAXopt, which
-# uses it as its default solver.
-class NormalCholesky(lx.AbstractLinearSolver):
-    def init(self, operator, options):
-        del options
-        matrix = operator.as_matrix()
-        factor, lower = jsp.linalg.cho_factor(matrix.T @ matrix)
-        assert lower is False
-        packed_structures = lx.internal.pack_structures(operator)
-        return matrix, factor, packed_structures
-
-    def compute(self, state, vector, options):
-        matrix, factor, packed_structures = state
-        vector = lx.internal.ravel_vector(vector, packed_structures)
-        solution = jsp.linalg.cho_solve((factor, False), matrix.T @ vector)
-        return (
-            lx.internal.unravel_solution(solution, packed_structures),
-            lx.RESULTS.successful,
-            {},
-        )
-
-    def transpose(self, state, options):
-        assert False
-
-    def conj(self, state, options):
-        assert False
-
-    def assume_full_rank(self) -> bool:
-        return True
-
-
 # Default option for Optimistix. (QR linear solver.)
 @jax.jit
 def optx_qr(init_parameters, y0s, values):
@@ -161,7 +126,7 @@ def optx_qr(init_parameters, y0s, values):
 def optx_normal_cg(init_parameters, y0s, values):
     # Explicitly set the number of iterations, to be sure we have the same number of
     # iterations between Optimistix and JAXopt.
-    cg = lx.NormalCG(atol=0, rtol=0, max_steps=10)
+    cg = lx.Normal(lx.CG(atol=0, rtol=0, max_steps=10))
     optx_solver = optx.LevenbergMarquardt(rtol=1e-8, atol=1e-8, linear_solver=cg)
     sol = optx.least_squares(
         residuals,
@@ -179,7 +144,7 @@ def optx_normal_cg(init_parameters, y0s, values):
 @jax.jit
 def optx_normal_cholesky(init_parameters, y0s, values):
     optx_solver = optx.LevenbergMarquardt(
-        rtol=1e-8, atol=1e-8, linear_solver=NormalCholesky()
+        rtol=1e-8, atol=1e-8, linear_solver=lx.Normal(lx.Cholesky())
     )
     sol = optx.least_squares(
         residuals,

--- a/benchmarks/levenberg-marquardt.py
+++ b/benchmarks/levenberg-marquardt.py
@@ -41,6 +41,7 @@ import diffrax as dfx  # pyright: ignore
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import jax.scipy as jsp
 import jaxopt  # pyright: ignore
 import lineax as lx
 import optimistix as optx
@@ -106,6 +107,40 @@ def residuals(parameters, y0s__values):
     return values - pred_values
 
 
+# Lineax deliberately doesn't offer this as a solver.
+# It's mostly just a worse version of QR. It runs at similar speed empirically (see the
+# benchmarks below), but is substantially less accurate.
+# Anyway, we have an implementation here to provide a fair comparison with JAXopt, which
+# uses it as its default solver.
+class NormalCholesky(lx.AbstractLinearSolver):
+    def init(self, operator, options):
+        del options
+        matrix = operator.as_matrix()
+        factor, lower = jsp.linalg.cho_factor(matrix.T @ matrix)
+        assert lower is False
+        packed_structures = lx.internal.pack_structures(operator)
+        return matrix, factor, packed_structures
+
+    def compute(self, state, vector, options):
+        matrix, factor, packed_structures = state
+        vector = lx.internal.ravel_vector(vector, packed_structures)
+        solution = jsp.linalg.cho_solve((factor, False), matrix.T @ vector)
+        return (
+            lx.internal.unravel_solution(solution, packed_structures),
+            lx.RESULTS.successful,
+            {},
+        )
+
+    def transpose(self, state, options):
+        assert False
+
+    def conj(self, state, options):
+        assert False
+
+    def assume_full_rank(self) -> bool:
+        return True
+
+
 # Default option for Optimistix. (QR linear solver.)
 @jax.jit
 def optx_qr(init_parameters, y0s, values):
@@ -126,7 +161,7 @@ def optx_qr(init_parameters, y0s, values):
 def optx_normal_cg(init_parameters, y0s, values):
     # Explicitly set the number of iterations, to be sure we have the same number of
     # iterations between Optimistix and JAXopt.
-    cg = lx.Normal(lx.CG(atol=0, rtol=0, max_steps=10))
+    cg = lx.NormalCG(atol=0, rtol=0, max_steps=10)
     optx_solver = optx.LevenbergMarquardt(rtol=1e-8, atol=1e-8, linear_solver=cg)
     sol = optx.least_squares(
         residuals,
@@ -144,7 +179,7 @@ def optx_normal_cg(init_parameters, y0s, values):
 @jax.jit
 def optx_normal_cholesky(init_parameters, y0s, values):
     optx_solver = optx.LevenbergMarquardt(
-        rtol=1e-8, atol=1e-8, linear_solver=lx.Normal(lx.Cholesky())
+        rtol=1e-8, atol=1e-8, linear_solver=NormalCholesky()
     )
     sol = optx.least_squares(
         residuals,

--- a/docs/api/linear_solvers.md
+++ b/docs/api/linear_solvers.md
@@ -1,0 +1,8 @@
+# Linear solvers
+
+[`optimistix.NewtonDescent`][], [`optimistix.IndirectDampedNewtonDescent`][], and related descents accept a `linear_solver` argument. The following solver is provided by Optimistix; any `lineax.AbstractLinearSolver` may also be used.
+
+::: optimistix.TruncatedCG
+    options:
+        members:
+            - __init__

--- a/docs/api/minimise.md
+++ b/docs/api/minimise.md
@@ -37,7 +37,6 @@ In addition to the following, note that the [Optax](https://github.com/deepmind/
         options:
             members:
                 - _prepare_step
-                - _build_new_state
 
 ??? abstract "`optimistix.AbstractQuasiNewton`"
 

--- a/docs/api/minimise.md
+++ b/docs/api/minimise.md
@@ -31,6 +31,14 @@ In addition to the following, note that the [Optax](https://github.com/deepmind/
 
 ---
 
+??? abstract "`optimistix.AbstractNewtonBase`"
+
+    ::: optimistix.AbstractNewtonBase
+        options:
+            members:
+                - _prepare_step
+                - _build_new_state
+
 ??? abstract "`optimistix.AbstractQuasiNewton`"
 
     ::: optimistix.AbstractQuasiNewton
@@ -68,6 +76,26 @@ In addition to the following, note that the [Optax](https://github.com/deepmind/
             members: none
 
 ::: optimistix.LBFGS
+    options:
+        members:
+            - __init__
+
+---
+
+??? abstract "`optimistix.AbstractNewtonMinimiser`"
+
+    ::: optimistix.AbstractNewtonMinimiser
+        options:
+            members: none
+
+::: optimistix.LineSearchNewton
+    options:
+        members:
+            - __init__
+
+---
+
+::: optimistix.TrustNewton
     options:
         members:
             - __init__

--- a/docs/api/searches/descents.md
+++ b/docs/api/searches/descents.md
@@ -46,3 +46,11 @@
     options:
         members:
             - __init__
+
+---
+
+::: optimistix.SteihaugCGDescent
+    options:
+        members:
+            - __init__
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,7 @@ nav:
     - Advanced API:
         - 'api/norms.md'
         - 'api/adjoints.md'
+        - 'api/linear_solvers.md'
         - Searches and descents:
             - 'api/searches/introduction.md'
             - 'api/searches/searches.md'

--- a/optimistix/__init__.py
+++ b/optimistix/__init__.py
@@ -81,8 +81,8 @@ from ._solver import (
     polak_ribiere as polak_ribiere,
     SteepestDescent as SteepestDescent,
     SteihaugCGDescent as SteihaugCGDescent,
-    TrustNewton as TrustNewton,
     TruncatedCG as TruncatedCG,
+    TrustNewton as TrustNewton,
 )
 
 

--- a/optimistix/__init__.py
+++ b/optimistix/__init__.py
@@ -42,6 +42,8 @@ from ._solver import (
     AbstractGaussNewton as AbstractGaussNewton,
     AbstractGradientDescent as AbstractGradientDescent,
     AbstractLBFGS as AbstractLBFGS,
+    AbstractNewtonBase as AbstractNewtonBase,
+    AbstractNewtonMinimiser as AbstractNewtonMinimiser,
     AbstractQuasiNewton as AbstractQuasiNewton,
     BacktrackingArmijo as BacktrackingArmijo,
     BestSoFarFixedPoint as BestSoFarFixedPoint,
@@ -69,6 +71,7 @@ from ._solver import (
     LearningRate as LearningRate,
     LevenbergMarquardt as LevenbergMarquardt,
     LinearTrustRegion as LinearTrustRegion,
+    LineSearchNewton as LineSearchNewton,
     NelderMead as NelderMead,
     Newton as Newton,
     NewtonDescent as NewtonDescent,
@@ -77,6 +80,9 @@ from ._solver import (
     OptaxMinimiser as OptaxMinimiser,
     polak_ribiere as polak_ribiere,
     SteepestDescent as SteepestDescent,
+    SteihaugCGDescent as SteihaugCGDescent,
+    TrustNewton as TrustNewton,
+    TruncatedCG as TruncatedCG,
 )
 
 

--- a/optimistix/_linear_solver/__init__.py
+++ b/optimistix/_linear_solver/__init__.py
@@ -1,0 +1,1 @@
+from .truncated_cg import TruncatedCG as TruncatedCG

--- a/optimistix/_linear_solver/truncated_cg.py
+++ b/optimistix/_linear_solver/truncated_cg.py
@@ -1,0 +1,358 @@
+"""Truncated CG linear solver for indefinite operators (Newton-CG).
+
+Started from a copy of lineax's CG implementation and modified to:
+- remove the positive-definite operator requirement
+- exit early on negative curvature instead of injecting NaN
+- optionally exit on a trust-region boundary crossing, with projection
+- support per-call rtol override (Eisenstat-Walker hook)
+"""
+
+from typing import Any, cast, TypeAlias
+
+import equinox as eqx
+import jax
+import jax.lax as lax
+import jax.numpy as jnp
+import jax.tree_util as jtu
+import lineax as lx
+from equinox.internal import ω
+from jaxtyping import Array, Bool, PyTree, Scalar
+from lineax._norm import max_norm as _lx_max_norm
+from lineax._solution import RESULTS as _lxRESULTS
+
+from .._misc import tree_dot, tree_full_like, tree_where
+
+
+def _find_boundary_tau(
+    p: Any,
+    d: Any,
+    delta_sq: Scalar,
+    neg_curv: Bool[Array, ""],
+    gamma: Scalar,
+    inner_prod: Scalar,
+) -> Scalar:
+    """Find the boundary τ such that ‖p + τ d‖² = delta_sq.
+
+    For boundary-crossing exits (`neg_curv=False`): returns the positive root
+    (forward step along d).
+
+    For negative-curvature exits (`neg_curv=True`): computes both roots ta ≤ tb
+    and returns the one that minimises the quadratic model Δm(τ) = τγ + ½τ²κ,
+    using the CG conjugacy identity r·d = -‖r‖² = -γ.  With κ = inner_prod ≤ 0
+    the parabola opens downward so the minimum is at the endpoint further from
+    the vertex — matching scipy's trust-ncg boundary selection.  τ may be
+    negative (stepping backward along d).
+    """
+    pd = cast(Scalar, tree_dot(p, d))
+    dd = cast(Scalar, tree_dot(d, d))
+    pp = cast(Scalar, tree_dot(p, p))
+    disc = pd**2 - dd * (pp - delta_sq)
+    sqrt_disc = jnp.sqrt(jnp.maximum(disc, 0.0))
+    safe_dd = jnp.where(dd > jnp.finfo(dd.dtype).eps, dd, 1.0)
+    ta = (-pd - sqrt_disc) / safe_dd  # smaller root
+    tb = (-pd + sqrt_disc) / safe_dd  # larger root (= positive root)
+    # For neg_curv: prefer ta when Δm(ta) < Δm(tb).
+    # Δm(τ) = τγ + ½τ²κ with γ = r·d = -‖r‖² = -gamma (CG identity).
+    # prefer_ta iff (ta-tb)[-gamma + ½(ta+tb)·κ] < 0, with ta-tb < 0, giving:
+    prefer_ta = -gamma + 0.5 * (ta + tb) * inner_prod > 0
+    tau_nc = jnp.where(prefer_ta, ta, tb)
+    tau_bnd = jnp.maximum(tb, 0.0)
+    return jnp.where(neg_curv, tau_nc, tau_bnd)
+
+
+_TruncatedCGState: TypeAlias = lx.AbstractLinearOperator
+
+
+class TruncatedCG(lx.AbstractLinearSolver[_TruncatedCGState]):
+    """CG solver for potentially indefinite operators, for use in Newton-CG.
+
+    Unlike `lineax.CG`, this solver does not require a positive-definite operator.
+    When negative curvature is detected (`d^T H d ≤ 0`), the solver exits early and
+    returns the current partial CG iterate as the descent direction. This is the
+    truncation strategy used by scipy's Newton-CG method.
+
+    On the first CG step, if negative curvature is detected before any progress has
+    been made (iterate is still zero), a Cauchy-scaled steepest-descent step
+    `‖g‖² / |d^T H d| · (-g)` is returned, matching scipy's Newton-CG fallback.
+
+    Supports the following `options` (passed to `lx.linear_solve(..., options=...)`):
+
+    - `"rtol"`: Override the solver's `rtol` for this call. Intended for the
+        Eisenstat-Walker tolerance schedule in Newton-CG, where the tolerance is
+        tightened as the outer iterate approaches the solution.
+    - `"atol"`: Override the solver's `atol` for this call.
+    - `"delta"`: Trust-region radius. If provided, the solver exits early when
+        `‖y‖ ≥ delta`, projects the step onto the trust-region boundary (solving
+        `‖p + τ d‖ = Δ`), and returns the projected step as `.value`. Negative
+        curvature exits are also projected onto the boundary when `delta` is finite.
+        Defaults to `jnp.inf` (no trust-region constraint, no projection).
+
+    - `y0`: Initial estimate of the solution. Defaults to all zeros.
+    """
+
+    rtol: float
+    atol: float
+    norm: Any = _lx_max_norm
+    stabilise_every: int | None = 10
+    max_steps: int | None = None
+
+    def __check_init__(self):
+        if isinstance(self.rtol, (int, float)) and self.rtol < 0:
+            raise ValueError("`TruncatedCG` requires `rtol >= 0`.")
+        if isinstance(self.atol, (int, float)) and self.atol < 0:
+            raise ValueError("`TruncatedCG` requires `atol >= 0`.")
+        if (
+            isinstance(self.atol, (int, float))
+            and isinstance(self.rtol, (int, float))
+            and self.atol == 0
+            and self.rtol == 0
+            and self.max_steps is None
+        ):
+            raise ValueError(
+                "Must specify `rtol`, `atol`, or `max_steps` (or some combination "
+                "of all three)."
+            )
+
+    def init(
+        self, operator: lx.AbstractLinearOperator, options: dict[str, Any]
+    ) -> _TruncatedCGState:
+        del options
+        # Unlike lineax.CG we do not require positive or negative semidefiniteness:
+        # TruncatedCG is designed to handle indefinite operators.
+        if not eqx.tree_equal(operator.in_structure(), operator.out_structure()):
+            raise ValueError(
+                "`TruncatedCG` may only be used for square linear operators."
+            )
+        return lx.linearise(operator)
+
+    def compute(
+        self,
+        state: _TruncatedCGState,
+        vector: PyTree[Array],
+        options: dict[str, Any],
+    ) -> tuple[PyTree[Array], _lxRESULTS, dict[str, Any]]:
+        operator = state
+
+        # Per-call overrides (Eisenstat-Walker, trust-region radius).
+        rtol = options.get("rtol", self.rtol)
+        atol = options.get("atol", self.atol)
+        delta = jnp.asarray(options.get("delta", jnp.inf))
+        delta_sq = delta**2
+
+        y0 = options.get("y0", tree_full_like(vector, 0))
+
+        leaves, _ = jtu.tree_flatten(vector)
+        size = sum(leaf.size for leaf in leaves)
+        if self.max_steps is None:
+            max_steps = 20 * size  # match scipy Newton-CG (cg_maxiter = 20*n)
+        else:
+            max_steps = self.max_steps
+
+        r0 = (vector**ω - operator.mv(y0) ** ω).ω
+        d0 = r0  # initial CG direction = initial residual (standard CG)
+        gamma0 = cast(Scalar, tree_dot(r0, r0))
+
+        has_scale = not (
+            isinstance(atol, (int, float))
+            and isinstance(rtol, (int, float))
+            and atol == 0
+            and rtol == 0
+        )
+        if has_scale:
+            b_scale = (atol + rtol * ω(vector).call(jnp.abs)).ω
+
+        def not_converged(r, diff, y):
+            if has_scale:
+                with jax.numpy_dtype_promotion("standard"):
+                    y_scale = (atol + rtol * ω(y).call(jnp.abs)).ω
+                    norm1 = self.norm((r**ω / b_scale**ω).ω)  # pyright: ignore
+                    norm2 = self.norm((diff**ω / y_scale**ω).ω)
+                return (norm1 > 1) | (norm2 > 1)
+            else:
+                return jnp.array(True)
+
+        class _CGState(eqx.Module):
+            diff: Any  # last step (for convergence check)
+            y: Any  # current iterate
+            r: Any  # current residual
+            d: Any  # current CG direction
+            gamma: Scalar  # r^T r
+            step: Scalar
+            done: Bool[Array, ""]  # neg_curv or boundary exit fired
+            neg_curv: Bool[Array, ""]  # negative curvature exit
+            hit_boundary: Bool[Array, ""]  # trust-region boundary exit
+            result_y: Any  # iterate to return at exit (y_before for early exits)
+            result_d: Any  # CG direction at exit (for boundary projection)
+
+        def cond_fun(cg_state: _CGState) -> Bool[Array, ""]:
+            out = cg_state.gamma > 0
+            out = out & (cg_state.step < max_steps)
+            out = out & not_converged(cg_state.r, cg_state.diff, cg_state.y)
+            out = out & ~cg_state.done
+            return out
+
+        def body_fun(cg_state: _CGState) -> _CGState:
+            mat_d = operator.mv(cg_state.d)
+            inner_prod = cast(Scalar, tree_dot(mat_d, cg_state.d))
+
+            # --- Departure from lineax.CG ---
+            # lineax.CG injects NaN when inner_prod is near-zero (lines 174-178).
+            # Instead we detect negative curvature explicitly and exit cleanly.
+            neg_curv = inner_prod <= jnp.finfo(jnp.result_type(*leaves)).eps
+            # Guard against division issues in the NaN-free path.
+            safe_inner_prod = jnp.where(neg_curv, 1.0, inner_prod)
+
+            alpha = cg_state.gamma / safe_inner_prod
+            diff = (alpha * cg_state.d**ω).ω
+            y_new = (cg_state.y**ω + diff**ω).ω
+
+            # --- Boundary exit (trust-region use) ---
+            y_new_norm_sq = cast(Scalar, tree_dot(y_new, y_new))
+            hit_boundary = y_new_norm_sq >= delta_sq
+
+            # Residual update — same periodic stabilisation as lineax.CG.
+            def stable_r():
+                return (vector**ω - operator.mv(y_new) ** ω).ω
+
+            def cheap_r():
+                return (cg_state.r**ω - alpha * mat_d**ω).ω
+
+            if self.stabilise_every == 1:
+                r_new = stable_r()
+            elif self.stabilise_every is None:
+                r_new = cheap_r()
+            else:
+                stable_step = (
+                    eqx.internal.unvmap_max(cg_state.step) % self.stabilise_every
+                ) == 0
+                stable_step = eqx.internal.nonbatchable(stable_step)
+                r_new = lax.cond(stable_step, stable_r, cheap_r)
+
+            gamma_new = cast(Scalar, tree_dot(r_new, r_new))
+            safe_gamma = jnp.where(
+                cg_state.gamma > jnp.finfo(gamma_new.dtype).eps, cg_state.gamma, 1.0
+            )
+            beta = gamma_new / safe_gamma
+            d_new = (r_new**ω + beta * cg_state.d**ω).ω
+
+            # Determine what to return if we exit here.
+            #
+            # Trust-region mode (delta finite): project onto the boundary sphere
+            # by solving ‖y_before + τ d‖ = Δ, for both neg_curv and boundary exits.
+            #
+            # Line-search mode (delta=inf): no projection.  On neg_curv at the very
+            # first step (y=0) fall back to d (= r0 = -g) so the Armijo search has
+            # a non-trivial descent direction; on later steps return y_before.
+            done_now = neg_curv | hit_boundary
+            should_project = done_now & ~jnp.isinf(delta)
+
+            y_is_zero = cast(Scalar, tree_dot(cg_state.y, cg_state.y)) <= 0
+            first_step_linesearch_fallback = y_is_zero & neg_curv & jnp.isinf(delta)
+            # Scipy scaling: return γ / |d^T H d| · d = ‖g‖² / |curv| · (-g),
+            # the Cauchy point along -g that matches the curvature magnitude.
+            # This lets Armijo start from alpha=1 and accept immediately rather
+            # than backtracking from an unscaled unit direction.
+            # Guard: when inner_prod ≈ 0 (barely neg-curv) avoid a huge step.
+            safe_neg_inner = jnp.maximum(-inner_prod, jnp.finfo(inner_prod.dtype).eps)
+            cauchy_d = (cg_state.gamma / safe_neg_inner * cg_state.d**ω).ω
+            y_before = tree_where(first_step_linesearch_fallback, cauchy_d, cg_state.y)
+
+            # Boundary-crossing: forward root. Neg-curv: best of both roots.
+            # Uses r·d = -γ (CG conjugacy identity) to pick without extra HVP.
+            tau = _find_boundary_tau(
+                cg_state.y, cg_state.d, delta_sq, neg_curv, cg_state.gamma, inner_prod
+            )
+            y_projected = (cg_state.y**ω + tau * cg_state.d**ω).ω
+
+            y_exit = tree_where(done_now, y_before, y_new)
+            result_y_now = tree_where(should_project, y_projected, y_exit)
+
+            return _CGState(
+                diff=diff,
+                y=y_new,
+                r=r_new,
+                d=d_new,
+                gamma=gamma_new,
+                step=cg_state.step + 1,
+                done=done_now,
+                neg_curv=neg_curv,
+                hit_boundary=hit_boundary,
+                result_y=result_y_now,
+                result_d=cg_state.d,
+            )
+
+        # Initialise result_y to r0 (= -g for Newton-CG) so that if max_steps=0
+        # the loop is skipped entirely and we still return a useful fallback.
+        # The actual first-step neg_curv fallback (Cauchy-scaled) is computed in
+        # body_fun and overwrites this via result_y_now.
+        init_state = _CGState(
+            diff=ω(y0).call(lambda x: jnp.full_like(x, jnp.inf)).ω,
+            y=y0,
+            r=r0,
+            d=d0,
+            gamma=gamma0,
+            step=jnp.array(0),
+            done=jnp.array(False),
+            neg_curv=jnp.array(False),
+            hit_boundary=jnp.array(False),
+            result_y=r0,
+            result_d=d0,
+        )
+
+        final = lax.while_loop(cond_fun, body_fun, init_state)
+
+        # If the loop exited via done (neg_curv or boundary), or via convergence
+        # (not_converged became False), result_y is set correctly by the last
+        # body_fun call. If max_steps was reached, result_y is the last y_new.
+        solution = final.result_y
+
+        if self.max_steps is None:
+            result = _lxRESULTS.where(
+                final.step == max_steps, _lxRESULTS.singular, _lxRESULTS.successful
+            )
+        elif has_scale:
+            result = _lxRESULTS.where(
+                final.step == max_steps,
+                _lxRESULTS.max_steps_reached,
+                _lxRESULTS.successful,
+            )
+        else:
+            result = _lxRESULTS.successful
+
+        stats = {
+            "num_steps": final.step,
+            "max_steps": jnp.array(max_steps),
+            "negative_curvature": final.neg_curv,
+            "hit_boundary": final.hit_boundary,
+            "direction": final.result_d,
+        }
+        return solution, result, stats
+
+    def transpose(
+        self, state: _TruncatedCGState, options: dict[str, Any]
+    ) -> tuple[_TruncatedCGState, dict[str, Any]]:
+        return state.transpose(), options
+
+    def conj(
+        self, state: _TruncatedCGState, options: dict[str, Any]
+    ) -> tuple[_TruncatedCGState, dict[str, Any]]:
+        return lx.conj(state), options
+
+    def assume_full_rank(self) -> bool:
+        return False
+
+
+TruncatedCG.__init__.__doc__ = """**Arguments:**
+
+- `rtol`: Relative tolerance for CG convergence. Can be overridden per-call via
+    `options["rtol"]` (e.g. for Eisenstat-Walker tolerance scheduling).
+- `atol`: Absolute tolerance for CG convergence. Can be overridden per-call via
+    `options["atol"]`.
+- `norm`: The norm to use for convergence checking. Defaults to `lineax.max_norm`.
+- `stabilise_every`: Recompute the residual exactly every this many steps to
+    correct floating-point drift. Matches `lineax.CG` default of 10.
+- `max_steps`: Maximum number of CG iterations. Defaults to `20 * n` (matching
+    scipy's Newton-CG `cg_maxiter = 20*n`). At max_steps the solve returns
+    `RESULTS.singular` (if `max_steps` was inferred) or
+    `RESULTS.max_steps_reached` (if set explicitly).
+"""

--- a/optimistix/_solver/__init__.py
+++ b/optimistix/_solver/__init__.py
@@ -1,3 +1,4 @@
+from .._linear_solver import TruncatedCG as TruncatedCG
 from .backtracking import BacktrackingArmijo as BacktrackingArmijo
 from .best_so_far import (
     BestSoFarFixedPoint as BestSoFarFixedPoint,
@@ -41,9 +42,16 @@ from .optax import OptaxMinimiser as OptaxMinimiser
 from .quasi_newton import (
     AbstractBFGS as AbstractBFGS,
     AbstractDFP as AbstractDFP,
+    AbstractNewtonBase as AbstractNewtonBase,
     AbstractQuasiNewton as AbstractQuasiNewton,
     BFGS as BFGS,
     DFP as DFP,
+)
+from .second_order import (
+    AbstractNewtonMinimiser as AbstractNewtonMinimiser,
+    LineSearchNewton as LineSearchNewton,
+    SteihaugCGDescent as SteihaugCGDescent,
+    TrustNewton as TrustNewton,
 )
 from .trust_region import (
     ClassicalTrustRegion as ClassicalTrustRegion,

--- a/optimistix/_solver/gauss_newton.py
+++ b/optimistix/_solver/gauss_newton.py
@@ -17,8 +17,10 @@ from .._misc import (
     filter_cond,
     max_norm,
     sum_squares,
+    tree_dot,
     tree_full_like,
     tree_where,
+    two_norm,
 )
 from .._search import (
     AbstractDescent,
@@ -34,6 +36,7 @@ def newton_step(
     | FunctionInfo.EvalGradHessianInv
     | FunctionInfo.ResidualJac,
     linear_solver: lx.AbstractLinearSolver,
+    options: dict[str, Any] | None = None,
 ) -> tuple[PyTree[Array], RESULTS]:
     """Compute a Newton step.
 
@@ -72,7 +75,9 @@ def newton_step(
                 "Cannot use a Newton descent with a solver that only evaluates the "
                 "gradient, or only the function itself."
             )
-        out = lx.linear_solve(operator, vector, linear_solver, throw=False)
+        out = lx.linear_solve(
+            operator, vector, linear_solver, options=options, throw=False
+        )
         newton = out.value
         result = RESULTS.promote(out.result)
     return newton, result
@@ -118,7 +123,29 @@ class NewtonDescent(
         state: _NewtonDescentState,
     ) -> _NewtonDescentState:
         del state
-        newton, result = newton_step(f_info, self.linear_solver)
+        # Eisenstat-Walker: pass an adaptive rtol to iterative linear solvers
+        # (e.g. TruncatedCG).  Direct solvers silently ignore options["rtol"].
+        # For EvalGradHessian the gradient is available; for other f_info types
+        # we leave options empty so callers are unaffected.
+        if isinstance(f_info, FunctionInfo.EvalGradHessian):
+            ew_rtol = jnp.minimum(0.5, jnp.sqrt(two_norm(f_info.grad)))
+            options: dict[str, Any] = {"rtol": ew_rtol}
+        else:
+            options = {}
+        newton, result = newton_step(f_info, self.linear_solver, options)
+        # Steepest-descent fallback: when the Newton direction is not a descent
+        # direction, fall back to the gradient so the Armijo line search can still
+        # make progress.  This mirrors scipy's newton-cg behaviour on the first CG
+        # step with negative curvature.
+        #
+        # Two cases trigger the fallback:
+        #   (a) the linear solve failed outright (e.g. Cholesky on indefinite H), or
+        #   (b) the solve "succeeded" but gᵀ(H⁻¹g) ≤ 0, which happens when H is
+        #       indefinite and the solver returns a direction that ascends rather
+        #       than descends (e.g. LU on a negative-definite Hessian).
+        if isinstance(f_info, FunctionInfo.EvalGradHessian):
+            is_descent = tree_dot(f_info.grad, newton) > 0
+            newton = tree_where(~is_descent, f_info.grad, newton)
         if self.norm is not None:
             newton = (newton**ω / self.norm(newton)).ω
         return _NewtonDescentState(newton, result)

--- a/optimistix/_solver/levenberg_marquardt.py
+++ b/optimistix/_solver/levenberg_marquardt.py
@@ -101,7 +101,7 @@ class DampedNewtonDescent(
     a line search expects the step to be smaller as the step size decreases.
     """
 
-    # Will probably resolve to either Cholesky (for minimisation problems) or
+    # Will probably resolve to either LU (for minimisation problems) or
     # QR (for least-squares problems).
     linear_solver: lx.AbstractLinearSolver = lx.AutoLinearSolver(well_posed=None)
 

--- a/optimistix/_solver/quasi_newton.py
+++ b/optimistix/_solver/quasi_newton.py
@@ -99,15 +99,168 @@ class _QuasiNewtonState(
     result: RESULTS
     # Used in compat.py
     num_accepted_steps: Int[Array, ""]
-    # update state
+    # Hessian approximation update state (None for exact-Newton)
     hessian_update_state: HessianUpdateState
 
 
+_BoundNewtonState = TypeVar("_BoundNewtonState", bound=_QuasiNewtonState)
+
+
+class AbstractNewtonBase(
+    AbstractMinimiser[Y, Aux, _BoundNewtonState], Generic[Y, Aux, _BoundNewtonState]
+):
+    """Abstract base class shared by exact-Newton and quasi-Newton minimisers.
+
+    Provides the common `AbstractVar` declarations and concrete `step`,
+    `terminate`, and `postprocess` implementations used by both exact-Newton
+    and quasi-Newton minimisers. Subclasses must implement `init` and the
+    two abstract hooks `_prepare_step` and `_build_new_state`.
+    """
+
+    rtol: AbstractVar[float]
+    atol: AbstractVar[float]
+    norm: AbstractVar[Callable[[PyTree], Scalar]]
+    descent: AbstractVar[AbstractDescent[Y, Any, Any]]
+    search: AbstractVar[AbstractSearch[Y, Any, FunctionInfo.Eval, Any]]
+    verbose: AbstractVar[Callable[..., None]]
+
+    @abc.abstractmethod
+    def _prepare_step(
+        self,
+        fn: Fn[Y, Scalar, Aux],
+        y: Y,
+        args: PyTree,
+        options: dict[str, Any],
+        state: _BoundNewtonState,
+        tags: frozenset[object],
+    ) -> tuple[Scalar, Aux, Callable[..., Any], Any]:
+        """Evaluate fn at ``state.y_eval`` and prepare the accepted branch.
+
+        Returns ``(f_eval, aux_eval, accepted_fn, hus_for_rejected)`` where:
+
+        - ``f_eval``: function value at ``state.y_eval``, passed to the line
+          search / trust region.
+        - ``aux_eval``: auxiliary output from ``fn``.
+        - ``accepted_fn``: closure ``accepted(descent_state) ->
+          (y, f_info, aux, descent_state, terminate, hessian_update_state)``
+          that builds the updated function-info and termination flag when the
+          search accepts the step.
+        - ``hus_for_rejected``: the ``hessian_update_state`` to carry through
+          unchanged when the step is rejected (``None`` for exact-Newton).
+        """
+
+    @abc.abstractmethod
+    def _build_new_state(
+        self,
+        old_state: _BoundNewtonState,
+        y_eval: Y,
+        search_state: Any,
+        f_info: Any,
+        aux: Aux,
+        descent_state: Any,
+        terminate: Bool[Array, ""],
+        result: RESULTS,
+        accept: Bool[Array, ""],
+        hessian_update_state: Any,
+    ) -> _BoundNewtonState:
+        """Construct the updated solver state after a step."""
+
+    def step(
+        self,
+        fn: Fn[Y, Scalar, Aux],
+        y: Y,
+        args: PyTree,
+        options: dict[str, Any],
+        state: _BoundNewtonState,
+        tags: frozenset[object],
+    ) -> tuple[Y, _BoundNewtonState, Aux]:
+        f_eval, aux_eval, accepted, hus_for_rejected = self._prepare_step(
+            fn, y, args, options, state, tags
+        )
+        step_size, accept, search_result, search_state = self.search.step(
+            state.first_step,
+            y,
+            state.y_eval,
+            state.f_info,
+            FunctionInfo.Eval(f_eval),
+            state.search_state,
+        )
+
+        def rejected(descent_state):
+            return (
+                y,
+                state.f_info,
+                state.aux,
+                descent_state,
+                jnp.array(False),
+                hus_for_rejected,
+            )
+
+        y, f_info, aux, descent_state, terminate, hessian_update_state = filter_cond(
+            accept, accepted, rejected, state.descent_state
+        )
+
+        self.verbose(
+            loss_this_step=("Loss on this step", f_eval),
+            loss_last_accepted_step=("Loss on the last accepted step", state.f_info.f),
+            step_size=("Step size", step_size),
+            y=("y", state.y_eval),
+            y_last_accepted_step=("y on the last accepted step", y),
+        )
+
+        y_descent, descent_result = self.descent.step(step_size, descent_state)
+        y_eval = (y**ω + y_descent**ω).ω
+        result = RESULTS.where(
+            search_result == RESULTS.successful, descent_result, search_result
+        )
+
+        prev_aux = tree_where(state.first_step, aux, state.aux)
+        state = self._build_new_state(
+            state,
+            y_eval,
+            search_state,
+            f_info,
+            aux,
+            descent_state,
+            terminate,
+            result,
+            accept,
+            hessian_update_state,
+        )
+        return y, state, prev_aux
+
+    def terminate(
+        self,
+        fn: Fn[Y, Scalar, Aux],
+        y: Y,
+        args: PyTree,
+        options: dict[str, Any],
+        state: _BoundNewtonState,
+        tags: frozenset[object],
+    ) -> tuple[Bool[Array, ""], RESULTS]:
+        return state.terminate, state.result
+
+    def postprocess(
+        self,
+        fn: Fn[Y, Scalar, Aux],
+        y: Y,
+        aux: Aux,
+        args: PyTree,
+        options: dict[str, Any],
+        state: _BoundNewtonState,
+        tags: frozenset[object],
+        result: RESULTS,
+    ) -> tuple[Y, Aux, dict[str, Any]]:
+        return y, aux, {}
+
+
 class AbstractQuasiNewton(
-    AbstractMinimiser[Y, Aux, _QuasiNewtonState],
+    AbstractNewtonBase[Y, Aux, _QuasiNewtonState],
     Generic[Y, Aux, _Hessian, HessianUpdateState],
 ):
     """Abstract quasi-Newton minimisation algorithm.
+
+    Subclasses [`optimistix.AbstractNewtonBase`][].
 
     Base class for quasi-Newton solvers, which create approximations to the Hessian or
     the inverse Hessian by accumulating gradient information over multiple iterations.
@@ -134,13 +287,9 @@ class AbstractQuasiNewton(
         function does not support reverse-mode automatic differentiation.
     """
 
-    rtol: AbstractVar[float]
-    atol: AbstractVar[float]
-    norm: AbstractVar[Callable[[PyTree], Scalar]]
     use_inverse: AbstractVar[bool]
     descent: AbstractVar[AbstractDescent[Y, _Hessian, Any]]
     search: AbstractVar[AbstractSearch[Y, _Hessian, FunctionInfo.Eval, Any]]
-    verbose: AbstractVar[Callable[..., None]]
 
     @abc.abstractmethod
     def init_hessian(
@@ -201,7 +350,7 @@ class AbstractQuasiNewton(
             hessian_update_state=hessian_update_state,
         )
 
-    def step(
+    def _prepare_step(
         self,
         fn: Fn[Y, Scalar, Aux],
         y: Y,
@@ -209,18 +358,10 @@ class AbstractQuasiNewton(
         options: dict[str, Any],
         state: _QuasiNewtonState,
         tags: frozenset[object],
-    ) -> tuple[Y, _QuasiNewtonState, Aux]:
+    ) -> tuple[Scalar, Aux, Callable[..., Any], HessianUpdateState]:
         autodiff_mode = options.get("autodiff_mode", "bwd")
         f_eval, lin_fn, aux_eval = jax.linearize(
             lambda _y: fn(_y, args), state.y_eval, has_aux=True
-        )
-        step_size, accept, search_result, search_state = self.search.step(
-            state.first_step,
-            y,
-            state.y_eval,
-            state.f_info,
-            FunctionInfo.Eval(f_eval),
-            state.search_state,
         )
 
         def accepted(descent_state):
@@ -256,36 +397,22 @@ class AbstractQuasiNewton(
                 hessian_update_state,
             )
 
-        def rejected(descent_state):
-            return (
-                y,
-                state.f_info,
-                state.aux,
-                descent_state,
-                jnp.array(False),
-                state.hessian_update_state,
-            )
+        return f_eval, aux_eval, accepted, state.hessian_update_state
 
-        y, f_info, aux, descent_state, terminate, hessian_update_state = filter_cond(
-            accept, accepted, rejected, state.descent_state
-        )
-
-        self.verbose(
-            loss_this_step=("Loss on this step", f_eval),
-            loss_last_accepted_step=("Loss on the last accepted step", state.f_info.f),
-            step_size=("Step size", step_size),
-            y=("y", state.y_eval),
-            y_last_accepted_step=("y on the last accepted step", y),
-        )
-
-        y_descent, descent_result = self.descent.step(step_size, descent_state)
-        y_eval = (y**ω + y_descent**ω).ω
-        result = RESULTS.where(
-            search_result == RESULTS.successful, descent_result, search_result
-        )
-
-        prev_aux = tree_where(state.first_step, aux, state.aux)
-        state = _QuasiNewtonState(
+    def _build_new_state(
+        self,
+        old_state: _QuasiNewtonState,
+        y_eval: Y,
+        search_state: Any,
+        f_info: _Hessian,
+        aux: Aux,
+        descent_state: Any,
+        terminate: Bool[Array, ""],
+        result: RESULTS,
+        accept: Bool[Array, ""],
+        hessian_update_state: HessianUpdateState,
+    ) -> _QuasiNewtonState:
+        return _QuasiNewtonState(
             first_step=jnp.array(False),
             y_eval=y_eval,
             search_state=search_state,
@@ -294,34 +421,9 @@ class AbstractQuasiNewton(
             descent_state=descent_state,
             terminate=terminate,
             result=result,
-            num_accepted_steps=state.num_accepted_steps + jnp.where(accept, 1, 0),
+            num_accepted_steps=old_state.num_accepted_steps + jnp.where(accept, 1, 0),
             hessian_update_state=hessian_update_state,
         )
-        return y, state, prev_aux
-
-    def terminate(
-        self,
-        fn: Fn[Y, Scalar, Aux],
-        y: Y,
-        args: PyTree,
-        options: dict[str, Any],
-        state: _QuasiNewtonState,
-        tags: frozenset[object],
-    ) -> tuple[Bool[Array, ""], RESULTS]:
-        return state.terminate, state.result
-
-    def postprocess(
-        self,
-        fn: Fn[Y, Scalar, Aux],
-        y: Y,
-        aux: Aux,
-        args: PyTree,
-        options: dict[str, Any],
-        state: _QuasiNewtonState,
-        tags: frozenset[object],
-        result: RESULTS,
-    ) -> tuple[Y, Aux, dict[str, Any]]:
-        return y, aux, {}
 
 
 class AbstractBFGS(AbstractQuasiNewton[Y, Aux, _Hessian, None]):

--- a/optimistix/_solver/quasi_newton.py
+++ b/optimistix/_solver/quasi_newton.py
@@ -103,18 +103,15 @@ class _QuasiNewtonState(
     hessian_update_state: HessianUpdateState
 
 
-_BoundNewtonState = TypeVar("_BoundNewtonState", bound=_QuasiNewtonState)
-
-
 class AbstractNewtonBase(
-    AbstractMinimiser[Y, Aux, _BoundNewtonState], Generic[Y, Aux, _BoundNewtonState]
+    AbstractMinimiser[Y, Aux, _QuasiNewtonState],
 ):
     """Abstract base class shared by exact-Newton and quasi-Newton minimisers.
 
     Provides the common `AbstractVar` declarations and concrete `step`,
     `terminate`, and `postprocess` implementations used by both exact-Newton
     and quasi-Newton minimisers. Subclasses must implement `init` and the
-    two abstract hooks `_prepare_step` and `_build_new_state`.
+    abstract hook `_prepare_step`.
     """
 
     rtol: AbstractVar[float]
@@ -131,7 +128,7 @@ class AbstractNewtonBase(
         y: Y,
         args: PyTree,
         options: dict[str, Any],
-        state: _BoundNewtonState,
+        state: _QuasiNewtonState,
         tags: frozenset[object],
     ) -> tuple[Scalar, Aux, Callable[..., Any], Any]:
         """Evaluate fn at ``state.y_eval`` and prepare the accepted branch.
@@ -149,31 +146,15 @@ class AbstractNewtonBase(
           unchanged when the step is rejected (``None`` for exact-Newton).
         """
 
-    @abc.abstractmethod
-    def _build_new_state(
-        self,
-        old_state: _BoundNewtonState,
-        y_eval: Y,
-        search_state: Any,
-        f_info: Any,
-        aux: Aux,
-        descent_state: Any,
-        terminate: Bool[Array, ""],
-        result: RESULTS,
-        accept: Bool[Array, ""],
-        hessian_update_state: Any,
-    ) -> _BoundNewtonState:
-        """Construct the updated solver state after a step."""
-
     def step(
         self,
         fn: Fn[Y, Scalar, Aux],
         y: Y,
         args: PyTree,
         options: dict[str, Any],
-        state: _BoundNewtonState,
+        state: _QuasiNewtonState,
         tags: frozenset[object],
-    ) -> tuple[Y, _BoundNewtonState, Aux]:
+    ) -> tuple[Y, _QuasiNewtonState, Aux]:
         f_eval, aux_eval, accepted, hus_for_rejected = self._prepare_step(
             fn, y, args, options, state, tags
         )
@@ -215,17 +196,17 @@ class AbstractNewtonBase(
         )
 
         prev_aux = tree_where(state.first_step, aux, state.aux)
-        state = self._build_new_state(
-            state,
-            y_eval,
-            search_state,
-            f_info,
-            aux,
-            descent_state,
-            terminate,
-            result,
-            accept,
-            hessian_update_state,
+        state = _QuasiNewtonState(
+            first_step=jnp.array(False),
+            y_eval=y_eval,
+            search_state=search_state,
+            f_info=f_info,
+            aux=aux,
+            descent_state=descent_state,
+            terminate=terminate,
+            result=result,
+            num_accepted_steps=state.num_accepted_steps + jnp.where(accept, 1, 0),
+            hessian_update_state=hessian_update_state,
         )
         return y, state, prev_aux
 
@@ -235,7 +216,7 @@ class AbstractNewtonBase(
         y: Y,
         args: PyTree,
         options: dict[str, Any],
-        state: _BoundNewtonState,
+        state: _QuasiNewtonState,
         tags: frozenset[object],
     ) -> tuple[Bool[Array, ""], RESULTS]:
         return state.terminate, state.result
@@ -247,7 +228,7 @@ class AbstractNewtonBase(
         aux: Aux,
         args: PyTree,
         options: dict[str, Any],
-        state: _BoundNewtonState,
+        state: _QuasiNewtonState,
         tags: frozenset[object],
         result: RESULTS,
     ) -> tuple[Y, Aux, dict[str, Any]]:
@@ -255,7 +236,7 @@ class AbstractNewtonBase(
 
 
 class AbstractQuasiNewton(
-    AbstractNewtonBase[Y, Aux, _QuasiNewtonState],
+    AbstractNewtonBase[Y, Aux],
     Generic[Y, Aux, _Hessian, HessianUpdateState],
 ):
     """Abstract quasi-Newton minimisation algorithm.
@@ -398,32 +379,6 @@ class AbstractQuasiNewton(
             )
 
         return f_eval, aux_eval, accepted, state.hessian_update_state
-
-    def _build_new_state(
-        self,
-        old_state: _QuasiNewtonState,
-        y_eval: Y,
-        search_state: Any,
-        f_info: _Hessian,
-        aux: Aux,
-        descent_state: Any,
-        terminate: Bool[Array, ""],
-        result: RESULTS,
-        accept: Bool[Array, ""],
-        hessian_update_state: HessianUpdateState,
-    ) -> _QuasiNewtonState:
-        return _QuasiNewtonState(
-            first_step=jnp.array(False),
-            y_eval=y_eval,
-            search_state=search_state,
-            f_info=f_info,
-            aux=aux,
-            descent_state=descent_state,
-            terminate=terminate,
-            result=result,
-            num_accepted_steps=old_state.num_accepted_steps + jnp.where(accept, 1, 0),
-            hessian_update_state=hessian_update_state,
-        )
 
 
 class AbstractBFGS(AbstractQuasiNewton[Y, Aux, _Hessian, None]):

--- a/optimistix/_solver/second_order.py
+++ b/optimistix/_solver/second_order.py
@@ -69,12 +69,11 @@ def _grad_hessian(
     autodiff_mode: str = "bwd",
 ) -> tuple[Y, lx.FunctionLinearOperator]:
     """Return ``(grad, hessian_operator)`` at ``y``."""
-    fn_no_aux = _NoAux(fn)
     if autodiff_mode == "bwd":
-        grad_fn = lambda _y: jax.grad(fn_no_aux)(_y, args)
+        grad_fn = jax.grad(_NoAux(fn))
     else:
-        grad_fn = lambda _y: jax.jacfwd(lambda y2: fn_no_aux(y2, args))(_y)
-    grad, hvp_fn = jax.linearize(grad_fn, y)
+        grad_fn = jax.jacfwd(_NoAux(fn))
+    grad, hvp_fn = jax.linearize(lambda _y: grad_fn(_y, args), y)
     hessian = lx.FunctionLinearOperator(
         hvp_fn, jax.eval_shape(lambda: y), frozenset({lx.symmetric_tag}) | tags
     )

--- a/optimistix/_solver/second_order.py
+++ b/optimistix/_solver/second_order.py
@@ -1,0 +1,490 @@
+"""Exact second-order Newton minimisers.
+
+This module provides:
+- [`optimistix.SteihaugCGDescent`][]: truncated CG for trust-region subproblems.
+- [`optimistix.AbstractNewtonMinimiser`][]: base class for exact-Hessian minimisers.
+- [`optimistix.LineSearchNewton`][]: Newton with Armijo line-search globalisation.
+- [`optimistix.TrustNewton`][]: Newton with classical trust-region globalisation.
+
+These differ from quasi-Newton methods (BFGS, L-BFGS) in that they evaluate the
+**exact** Hessian via JAX automatic differentiation at each accepted step, using
+a `lineax.JacobianLinearOperator` over `jax.grad(f)` tagged as symmetric.
+This means the Hessian is never materialised: it is a lazy operator that computes
+Hessian-vector products via forward-over-reverse AD on demand.
+
+Solvers such as [`optimistix.NewtonDescent`][] will materialise the operator if
+their linear solver requires a dense matrix (e.g. `lineax.Cholesky()`), while
+[`optimistix.SteihaugCGDescent`][] uses Hessian-vector products directly and
+never needs the full matrix.
+
+For large-scale problems consider [`optimistix.BFGS`][] or [`optimistix.LBFGS`][].
+
+### Comparison with the quasi-Newton solvers in optimistix
+
+| Attribute          | BFGS / L-BFGS                | LineSearchNewton / TrustNewton  |
+|--------------------|------------------------------|---------------------------------|
+| Hessian            | Approximate (rank-2 update)  | Exact (FunctionLinearOperator)  |
+| Cost per HVP       | O(n)                         | O(cost of one grad eval)        |
+| Non-convex support | Limited (requires PD approx) | TrustNewton + SteihaugCGDescent |
+| Good for           | Large-scale problems         | Small/medium, accurate solution |
+"""
+
+from collections.abc import Callable
+from typing import Any, Generic
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.tree_util as jtu
+import lineax as lx
+from equinox import AbstractVar
+from equinox.internal import ω
+from jaxtyping import Array, Bool, PyTree, Scalar
+
+from .._custom_types import Aux, Fn, Y
+from .._linear_solver import TruncatedCG
+from .._misc import (
+    cauchy_termination,
+    default_verbose,
+    max_norm,
+    tree_full_like,
+    two_norm,
+)
+from .._search import AbstractDescent, AbstractSearch, FunctionInfo
+from .._solution import RESULTS
+from .backtracking import BacktrackingArmijo
+from .gauss_newton import NewtonDescent
+from .levenberg_marquardt import IndirectDampedNewtonDescent
+from .newton_chord import _NoAux
+from .quasi_newton import _QuasiNewtonState, AbstractNewtonBase
+from .trust_region import ClassicalTrustRegion
+
+
+def _grad_fn(fn: Fn[Y, Scalar, Aux], args: PyTree, autodiff_mode: str):
+    """Return a callable y -> gradient, honouring autodiff_mode."""
+    fn_no_aux = _NoAux(fn)
+    if autodiff_mode == "bwd":
+        return lambda _y: jax.grad(fn_no_aux)(_y, args)
+    else:
+        return lambda _y: jax.jacfwd(lambda y2: fn_no_aux(y2, args))(_y)
+
+
+def _make_hessian_f_info(
+    fn: Fn[Y, Scalar, Aux],
+    y: Y,
+    args: PyTree,
+    tags: frozenset[object],
+    *,
+    autodiff_mode: str = "bwd",
+) -> tuple[FunctionInfo.EvalGradHessian, Aux]:
+    f_val, aux = fn(y, args)
+    grad, hess_mv_fn = jax.linearize(_grad_fn(fn, args, autodiff_mode), y)
+    hessian = lx.FunctionLinearOperator(
+        hess_mv_fn, jax.eval_shape(lambda: y), frozenset({lx.symmetric_tag}) | tags
+    )
+    return FunctionInfo.EvalGradHessian(f_val, grad, hessian), aux
+
+
+# ---------------------------------------------------------------------------
+# SteihaugCGDescent
+# ---------------------------------------------------------------------------
+
+
+class _SteihaugCGDescentState(eqx.Module, Generic[Y]):
+    f_info: FunctionInfo.EvalGradHessian
+    grad_norm: Scalar  # ||g||, used to scale the trust-region radius
+
+
+class SteihaugCGDescent(
+    AbstractDescent[
+        Y,
+        FunctionInfo.EvalGradHessian,
+        _SteihaugCGDescentState,
+    ],
+):
+    """Steihaug-Toint truncated CG for trust-region subproblems.
+
+    Approximately solves the trust-region subproblem
+
+    ```
+    min  g^T p + 0.5 p^T H p
+    s.t. ||p|| <= Δ
+    ```
+
+    using conjugate gradients that terminate early when:
+
+    1. **Negative curvature**: `d^T H d ≤ 0`. The current search direction is
+       extended to the trust-region boundary and returned.
+    2. **Boundary hit**: the unconstrained CG step would leave the trust region.
+       The step is projected back onto the boundary and returned.
+    3. **CG convergence**: `||r_j|| < eta_j * ||g||` where
+       `eta_j = min(rtol, sqrt(||g||))` is the Eisenstat-Walker forcing sequence.
+       The current iterate is returned.
+
+    Hessian-vector products are computed lazily via forward-over-reverse AD
+    (`jax.jvp` of the gradient), so the full Hessian is never materialised.
+    This makes the per-step cost O(k * cost_of_grad) for k CG iterations rather
+    than O(n²).
+
+    Because no Cholesky factorisation is required and negative curvature is
+    handled gracefully, this descent is suitable for **non-convex** problems
+    where the Hessian may be indefinite.
+
+    Designed for use with [`optimistix.TrustNewton`][].
+    """
+
+    max_steps: int | None = None
+    rtol: float = 0.5
+
+    def init(
+        self,
+        y: Y,
+        f_info_struct: FunctionInfo.EvalGradHessian,
+    ) -> _SteihaugCGDescentState:
+        f_info_init = tree_full_like(f_info_struct, 0, allow_static=True)
+        return _SteihaugCGDescentState(f_info=f_info_init, grad_norm=jnp.array(0.0))
+
+    def query(
+        self,
+        y: Y,
+        f_info: FunctionInfo.EvalGradHessian,
+        state: _SteihaugCGDescentState,
+    ) -> _SteihaugCGDescentState:
+        del y, state
+        return _SteihaugCGDescentState(f_info=f_info, grad_norm=two_norm(f_info.grad))
+
+    def step(
+        self, step_size: Scalar, state: _SteihaugCGDescentState
+    ) -> tuple[Y, RESULTS]:
+        g = state.f_info.grad
+        H = state.f_info.hessian
+        delta = state.grad_norm * step_size
+
+        # Eisenstat-Walker: tighten the inner CG tolerance as ||g|| → 0.
+        # ew_rtol = min(rtol, sqrt(||g||)) gives the adaptive forcing sequence.
+        # At large ||g|| this caps at self.rtol (0.5 by default); as the outer
+        # iterate converges the inner solve is tightened automatically.
+        ew_rtol = jnp.minimum(jnp.array(self.rtol), jnp.sqrt(state.grad_norm))
+
+        # TruncatedCG solves H p = -g.  With a finite delta it handles both
+        # early exits (negative curvature and boundary crossing) internally,
+        # projecting onto the trust-region sphere and returning the result
+        # directly as .value.
+        out = lx.linear_solve(
+            H,
+            jtu.tree_map(jnp.negative, g),
+            TruncatedCG(rtol=self.rtol, atol=0.0, max_steps=self.max_steps),
+            options={"delta": delta, "rtol": ew_rtol},
+            throw=False,
+        )
+        return out.value, RESULTS.successful
+
+
+SteihaugCGDescent.__init__.__doc__ = """**Arguments:**
+
+- `max_steps`: Maximum number of CG iterations per outer Newton step. Defaults
+    to `None`, which falls through to `TruncatedCG`'s default of `20 * n`.
+    Set explicitly to impose a hard cap (e.g. for large problems).
+- `rtol`: Upper bound for the Eisenstat-Walker forcing sequence. The inner CG
+    terminates when `||r_j|| < eta_j * ||g||` where
+    `eta_j = min(rtol, sqrt(||g||))`. At large `||g||` this caps at `rtol`
+    (coarse inner solve); as `||g|| → 0` the inner tolerance is tightened
+    automatically, matching scipy's trust-ncg behaviour. Defaults to 0.5.
+"""
+
+
+# ---------------------------------------------------------------------------
+# AbstractNewtonMinimiser
+# ---------------------------------------------------------------------------
+
+
+class AbstractNewtonMinimiser(
+    AbstractNewtonBase[Y, Aux, _QuasiNewtonState],
+    Generic[Y, Aux],
+):
+    """Abstract base class for exact second-order Newton minimisers.
+
+    Subclasses [`optimistix.AbstractNewtonBase`][].
+
+    Subclasses evaluate the **exact Hessian** at each accepted step using a
+    `lineax.JacobianLinearOperator` wrapping `jax.grad(fn)`, tagged as
+    symmetric. The Hessian is never materialised: Hessian-vector products are
+    computed lazily via forward-over-reverse AD. If the chosen linear solver
+    (e.g. `lineax.Cholesky()`) needs a dense matrix it will materialise on
+    demand, but [`optimistix.SteihaugCGDescent`][] avoids this entirely.
+
+    Subclasses must provide the following attributes:
+
+    - `rtol: float`
+    - `atol: float`
+    - `norm: Callable[[PyTree], Scalar]`
+    - `descent: AbstractDescent[Y, FunctionInfo.EvalGradHessian, Any]`
+    - `search: AbstractSearch[Y, FunctionInfo.EvalGradHessian, FunctionInfo.Eval, Any]`
+    - `verbose: Callable[..., None]`
+
+    Supports the following `options`:
+
+    - `autodiff_mode`: whether to use forward- or reverse-mode autodifferentiation
+        to compute the gradient. Can be either `"fwd"` or `"bwd"`. Defaults to
+        `"bwd"`.
+    """
+
+    descent: AbstractVar[AbstractDescent[Y, FunctionInfo.EvalGradHessian, Any]]
+    search: AbstractVar[
+        AbstractSearch[Y, FunctionInfo.EvalGradHessian, FunctionInfo.Eval, Any]
+    ]
+
+    def init(
+        self,
+        fn: Fn[Y, Scalar, Aux],
+        y: Y,
+        args: PyTree,
+        options: dict[str, Any],
+        f_struct: jax.ShapeDtypeStruct,
+        aux_struct: PyTree[jax.ShapeDtypeStruct],
+        tags: frozenset[object],
+    ) -> _QuasiNewtonState:
+        autodiff_mode = options.get("autodiff_mode", "bwd")
+        f_info_struct, _ = eqx.filter_eval_shape(
+            _make_hessian_f_info, fn, y, args, tags, autodiff_mode=autodiff_mode
+        )
+        f_info = tree_full_like(f_info_struct, 0, allow_static=True)
+        return _QuasiNewtonState(
+            first_step=jnp.array(True),
+            y_eval=y,
+            search_state=self.search.init(y, f_info_struct),
+            f_info=f_info,
+            aux=tree_full_like(aux_struct, 0),
+            descent_state=self.descent.init(y, f_info_struct),
+            terminate=jnp.array(False),
+            result=RESULTS.successful,
+            num_accepted_steps=jnp.array(0),
+            hessian_update_state=None,
+        )
+
+    def _prepare_step(
+        self,
+        fn: Fn[Y, Scalar, Aux],
+        y: Y,
+        args: PyTree,
+        options: dict[str, Any],
+        state: _QuasiNewtonState,
+        tags: frozenset[object],
+    ) -> tuple[Scalar, Aux, Callable[..., Any], None]:
+        autodiff_mode = options.get("autodiff_mode", "bwd")
+        f_eval, aux_eval = fn(state.y_eval, args)
+        _gfn = _grad_fn(fn, args, autodiff_mode)
+
+        def accepted(descent_state):
+            grad, hess_mv_fn = jax.linearize(_gfn, state.y_eval)
+            hessian = lx.FunctionLinearOperator(
+                hess_mv_fn,
+                jax.eval_shape(lambda: state.y_eval),
+                frozenset({lx.symmetric_tag}) | tags,
+            )
+            # Swap in residuals from this step while keeping the static jaxpr
+            # from state, so filter_cond sees identical treedefs in both branches.
+            dynamic = eqx.filter(hessian, eqx.is_array)
+            static = eqx.filter(state.f_info.hessian, eqx.is_array, inverse=True)
+            hessian = eqx.combine(dynamic, static)
+
+            f_eval_info = FunctionInfo.EvalGradHessian(f_eval, grad, hessian)
+            descent_state = self.descent.query(state.y_eval, f_eval_info, descent_state)
+
+            y_diff = (state.y_eval**ω - y**ω).ω
+            f_diff = (f_eval**ω - state.f_info.f**ω).ω
+            terminate = cauchy_termination(
+                self.rtol, self.atol, self.norm, state.y_eval, y_diff, f_eval, f_diff
+            )
+            terminate = jnp.where(state.first_step, jnp.array(False), terminate)
+            return (
+                state.y_eval,
+                f_eval_info,
+                aux_eval,
+                descent_state,
+                terminate,
+                None,
+            )
+
+        return f_eval, aux_eval, accepted, None
+
+    def _build_new_state(
+        self,
+        old_state: _QuasiNewtonState,
+        y_eval: Y,
+        search_state: Any,
+        f_info: FunctionInfo.EvalGradHessian,
+        aux: Aux,
+        descent_state: Any,
+        terminate: Bool[Array, ""],
+        result: RESULTS,
+        accept: Bool[Array, ""],
+        hessian_update_state: None,
+    ) -> _QuasiNewtonState:
+        return _QuasiNewtonState(
+            first_step=jnp.array(False),
+            y_eval=y_eval,
+            search_state=search_state,
+            f_info=f_info,
+            aux=aux,
+            descent_state=descent_state,
+            terminate=terminate,
+            result=result,
+            num_accepted_steps=old_state.num_accepted_steps + jnp.where(accept, 1, 0),
+            hessian_update_state=None,
+        )
+
+
+# ---------------------------------------------------------------------------
+# LineSearchNewton
+# ---------------------------------------------------------------------------
+
+
+class LineSearchNewton(AbstractNewtonMinimiser[Y, Aux]):
+    """Newton minimiser with Armijo backtracking line-search globalisation.
+
+    At each accepted step an exact Hessian-vector-product operator is built via
+    `jax.grad` and `lineax.JacobianLinearOperator`, then the Newton system
+    `H δ = -g` is solved to obtain the search direction. An Armijo backtracking
+    line search then finds an acceptable step length.
+
+    This is a good choice for **convex or near-convex** problems where the
+    Hessian is guaranteed to be (or very close to) positive definite. For
+    non-convex problems where the Hessian can be indefinite, prefer
+    [`optimistix.TrustNewton`][] with [`optimistix.SteihaugCGDescent`][].
+
+    Supports the following `options`:
+
+    - `autodiff_mode`: `"fwd"` or `"bwd"`. Defaults to `"bwd"`.
+    """
+
+    rtol: float
+    atol: float
+    norm: Callable[[PyTree], Scalar]
+    descent: NewtonDescent
+    search: BacktrackingArmijo
+    verbose: Callable[..., None]
+
+    def __init__(
+        self,
+        rtol: float,
+        atol: float,
+        norm: Callable[[PyTree], Scalar] = max_norm,
+        linear_solver: lx.AbstractLinearSolver = lx.AutoLinearSolver(well_posed=True),
+        verbose: bool | Callable[..., None] = False,
+    ):
+        self.rtol = rtol
+        self.atol = atol
+        self.norm = norm
+        self.descent = NewtonDescent(linear_solver=linear_solver)
+        self.search = BacktrackingArmijo()
+        self.verbose = default_verbose(verbose)
+
+
+LineSearchNewton.__init__.__doc__ = """**Arguments:**
+
+- `rtol`: Relative tolerance for terminating the solve.
+- `atol`: Absolute tolerance for terminating the solve.
+- `norm`: The norm used to determine the difference between two iterates in the
+    convergence criteria. Should be any function `PyTree -> Scalar`. Optimistix
+    includes three built-in norms: [`optimistix.max_norm`][],
+    [`optimistix.rms_norm`][], and [`optimistix.two_norm`][].
+- `linear_solver`: The linear solver used to solve `H δ = -g`. Defaults to
+    `lineax.AutoLinearSolver(well_posed=True)`, which assumes the Hessian is
+    square and non-singular and dispatches to LU. Use
+    `lineax.CG(rtol=..., atol=...)` for large problems, or
+    [`optimistix.TruncatedCG`][] to handle indefinite Hessians.
+- `verbose`: Whether to print out extra information about how the solve is
+    proceeding. Can be `False`, `True`, or a callable `**kwargs -> None`.
+"""
+
+
+# ---------------------------------------------------------------------------
+# TrustNewton
+# ---------------------------------------------------------------------------
+
+_UNSET = object()
+
+
+class TrustNewton(AbstractNewtonMinimiser[Y, Aux]):
+    """Newton minimiser with classical trust-region globalisation.
+
+    At each accepted step an exact Hessian-vector-product operator is built via
+    `jax.grad` and `lineax.JacobianLinearOperator`, then the trust-region
+    subproblem is solved. Two descent directions are supported:
+
+    - **`IndirectDampedNewtonDescent`** (default): solves the true trust-region
+      subproblem by root-finding for the Levenberg--Marquardt parameter λ such
+      that `‖(H + λI)⁻¹g‖ = Δ` (Conn, Gould, Toint §7.3). Handles indefinite
+      Hessians correctly by ensuring `H + λI` is positive definite.
+    - **`SteihaugCGDescent`**: solves the trust-region subproblem approximately
+      via truncated CG. Handles indefinite Hessians gracefully, never
+      materialises the Hessian, and is preferred for **large-scale** problems.
+
+    To use `SteihaugCGDescent`, pass `use_steihaug=True`.
+
+    Supports the following `options`:
+
+    - `autodiff_mode`: `"fwd"` or `"bwd"`. Defaults to `"bwd"`.
+    """
+
+    rtol: float
+    atol: float
+    norm: Callable[[PyTree], Scalar]
+    descent: IndirectDampedNewtonDescent | SteihaugCGDescent
+    search: ClassicalTrustRegion
+    verbose: Callable[..., None]
+
+    def __init__(
+        self,
+        rtol: float,
+        atol: float,
+        norm: Callable[[PyTree], Scalar] = max_norm,
+        linear_solver: lx.AbstractLinearSolver = _UNSET,  # type: ignore[assignment]
+        use_steihaug: bool = False,
+        steihaug_max_steps: int | None = None,
+        verbose: bool | Callable[..., None] = False,
+    ):
+        if use_steihaug and linear_solver is not _UNSET:
+            raise ValueError(
+                "`linear_solver` has no effect when `use_steihaug=True` because "
+                "`SteihaugCGDescent` constructs its own `TruncatedCG` solver "
+                "internally. Either remove `linear_solver` or set "
+                "`use_steihaug=False`."
+            )
+        if linear_solver is _UNSET:
+            linear_solver = lx.AutoLinearSolver(well_posed=True)
+        self.rtol = rtol
+        self.atol = atol
+        self.norm = norm
+        if use_steihaug:
+            self.descent = SteihaugCGDescent(max_steps=steihaug_max_steps)
+        else:
+            self.descent = IndirectDampedNewtonDescent(linear_solver=linear_solver)
+        self.search = ClassicalTrustRegion()
+        self.verbose = default_verbose(verbose)
+
+
+TrustNewton.__init__.__doc__ = """**Arguments:**
+
+- `rtol`: Relative tolerance for terminating the solve.
+- `atol`: Absolute tolerance for terminating the solve.
+- `norm`: The norm used to determine the difference between two iterates in the
+    convergence criteria. Should be any function `PyTree -> Scalar`. Optimistix
+    includes three built-in norms: [`optimistix.max_norm`][],
+    [`optimistix.rms_norm`][], and [`optimistix.two_norm`][].
+- `linear_solver`: The linear solver used inside `IndirectDampedNewtonDescent`
+    when `use_steihaug=False`. Defaults to
+    `lineax.AutoLinearSolver(well_posed=True)`, which assumes the (shifted)
+    Hessian is square and non-singular and dispatches to LU. Passing
+    `linear_solver` together with `use_steihaug=True` is an error:
+    `SteihaugCGDescent` constructs its own internal solver and does not use
+    this argument.
+- `use_steihaug`: If `True`, use [`optimistix.SteihaugCGDescent`][] to solve
+    the trust-region subproblem via truncated CG. This handles indefinite
+    Hessians and is recommended for non-convex problems.
+- `steihaug_max_steps`: Maximum CG iterations per outer Newton step when
+    `use_steihaug=True`. Defaults to `None` (`TruncatedCG` uses `20 * n`).
+- `verbose`: Whether to print out extra information about how the solve is
+    proceeding. Can be `False`, `True`, or a callable `**kwargs -> None`.
+"""

--- a/optimistix/_solver/second_order.py
+++ b/optimistix/_solver/second_order.py
@@ -39,7 +39,7 @@ import jax.tree_util as jtu
 import lineax as lx
 from equinox import AbstractVar
 from equinox.internal import ω
-from jaxtyping import Array, Bool, PyTree, Scalar
+from jaxtyping import PyTree, Scalar
 
 from .._custom_types import Aux, Fn, Y
 from .._linear_solver import TruncatedCG
@@ -60,29 +60,25 @@ from .quasi_newton import _QuasiNewtonState, AbstractNewtonBase
 from .trust_region import ClassicalTrustRegion
 
 
-def _grad_fn(fn: Fn[Y, Scalar, Aux], args: PyTree, autodiff_mode: str):
-    """Return a callable y -> gradient, honouring autodiff_mode."""
-    fn_no_aux = _NoAux(fn)
-    if autodiff_mode == "bwd":
-        return lambda _y: jax.grad(fn_no_aux)(_y, args)
-    else:
-        return lambda _y: jax.jacfwd(lambda y2: fn_no_aux(y2, args))(_y)
-
-
-def _make_hessian_f_info(
+def _grad_hessian(
     fn: Fn[Y, Scalar, Aux],
     y: Y,
     args: PyTree,
     tags: frozenset[object],
     *,
     autodiff_mode: str = "bwd",
-) -> tuple[FunctionInfo.EvalGradHessian, Aux]:
-    f_val, aux = fn(y, args)
-    grad, hess_mv_fn = jax.linearize(_grad_fn(fn, args, autodiff_mode), y)
+) -> tuple[Y, lx.FunctionLinearOperator]:
+    """Return ``(grad, hessian_operator)`` at ``y``."""
+    fn_no_aux = _NoAux(fn)
+    if autodiff_mode == "bwd":
+        grad_fn = lambda _y: jax.grad(fn_no_aux)(_y, args)
+    else:
+        grad_fn = lambda _y: jax.jacfwd(lambda y2: fn_no_aux(y2, args))(_y)
+    grad, hvp_fn = jax.linearize(grad_fn, y)
     hessian = lx.FunctionLinearOperator(
-        hess_mv_fn, jax.eval_shape(lambda: y), frozenset({lx.symmetric_tag}) | tags
+        hvp_fn, jax.eval_shape(lambda: y), frozenset({lx.symmetric_tag}) | tags
     )
-    return FunctionInfo.EvalGradHessian(f_val, grad, hessian), aux
+    return grad, hessian
 
 
 # ---------------------------------------------------------------------------
@@ -199,7 +195,7 @@ SteihaugCGDescent.__init__.__doc__ = """**Arguments:**
 
 
 class AbstractNewtonMinimiser(
-    AbstractNewtonBase[Y, Aux, _QuasiNewtonState],
+    AbstractNewtonBase[Y, Aux],
     Generic[Y, Aux],
 ):
     """Abstract base class for exact second-order Newton minimisers.
@@ -245,10 +241,14 @@ class AbstractNewtonMinimiser(
         tags: frozenset[object],
     ) -> _QuasiNewtonState:
         autodiff_mode = options.get("autodiff_mode", "bwd")
-        f_info_struct, _ = eqx.filter_eval_shape(
-            _make_hessian_f_info, fn, y, args, tags, autodiff_mode=autodiff_mode
+        f = tree_full_like(f_struct, 0)
+        grad = tree_full_like(y, 0)
+        hessian_struct = eqx.filter_eval_shape(
+            lambda: _grad_hessian(fn, y, args, tags, autodiff_mode=autodiff_mode)[1]
         )
-        f_info = tree_full_like(f_info_struct, 0, allow_static=True)
+        hessian = tree_full_like(hessian_struct, 0, allow_static=True)
+        f_info = FunctionInfo.EvalGradHessian(f, grad, hessian)
+        f_info_struct = eqx.filter_eval_shape(lambda: f_info)
         return _QuasiNewtonState(
             first_step=jnp.array(True),
             y_eval=y,
@@ -273,14 +273,10 @@ class AbstractNewtonMinimiser(
     ) -> tuple[Scalar, Aux, Callable[..., Any], None]:
         autodiff_mode = options.get("autodiff_mode", "bwd")
         f_eval, aux_eval = fn(state.y_eval, args)
-        _gfn = _grad_fn(fn, args, autodiff_mode)
 
         def accepted(descent_state):
-            grad, hess_mv_fn = jax.linearize(_gfn, state.y_eval)
-            hessian = lx.FunctionLinearOperator(
-                hess_mv_fn,
-                jax.eval_shape(lambda: state.y_eval),
-                frozenset({lx.symmetric_tag}) | tags,
+            grad, hessian = _grad_hessian(
+                fn, state.y_eval, args, tags, autodiff_mode=autodiff_mode
             )
             # Swap in residuals from this step while keeping the static jaxpr
             # from state, so filter_cond sees identical treedefs in both branches.
@@ -307,32 +303,6 @@ class AbstractNewtonMinimiser(
             )
 
         return f_eval, aux_eval, accepted, None
-
-    def _build_new_state(
-        self,
-        old_state: _QuasiNewtonState,
-        y_eval: Y,
-        search_state: Any,
-        f_info: FunctionInfo.EvalGradHessian,
-        aux: Aux,
-        descent_state: Any,
-        terminate: Bool[Array, ""],
-        result: RESULTS,
-        accept: Bool[Array, ""],
-        hessian_update_state: None,
-    ) -> _QuasiNewtonState:
-        return _QuasiNewtonState(
-            first_step=jnp.array(False),
-            y_eval=y_eval,
-            search_state=search_state,
-            f_info=f_info,
-            aux=aux,
-            descent_state=descent_state,
-            terminate=terminate,
-            result=result,
-            num_accepted_steps=old_state.num_accepted_steps + jnp.where(accept, 1, 0),
-            hessian_update_state=None,
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ tests = [
   "optax>=0.2.4",
   "pytest>=8.3.5",
   "jaxlib",
+  "jaxopt",
   "sif2jax",
   "fire",
   "matplotlib"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -262,7 +262,9 @@ _general_minimisers = (
     # TruncatedCG / use_steihaug=True handle indefinite Hessians without it.
     optx.LineSearchNewton(rtol, atol),
     optx.LineSearchNewton(rtol, atol, linear_solver=lx.CG(rtol=1e-6, atol=0.0)),
-    optx.LineSearchNewton(rtol, atol, linear_solver=optx.TruncatedCG(rtol=0.5, atol=0.0)),
+    optx.LineSearchNewton(
+        rtol, atol, linear_solver=optx.TruncatedCG(rtol=0.5, atol=0.0)
+    ),
     optx.TrustNewton(rtol, atol),
     optx.TrustNewton(rtol, atol, linear_solver=lx.CG(rtol=1e-6, atol=0.0)),
     optx.TrustNewton(rtol, atol, use_steihaug=True),
@@ -583,7 +585,6 @@ minimisation_fn_minima_init_args = (
 
 # Problems with a globally PSD Hessian; lx.CG-based Newton requires this.
 _spd_minimisation_fns = frozenset({bowl, matyas, square_minus_one, globally_convex})
-
 
 
 # ROOT FIND/FIXED POINT PROBLEMS

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -258,6 +258,14 @@ _general_minimisers = (
     optx.OptaxMinimiser(optax.adam(learning_rate=3e-3), rtol=rtol, atol=atol),
     # optax.lbfgs includes their linesearch by default
     optx.OptaxMinimiser(optax.lbfgs(), rtol=rtol, atol=atol),
+    # Exact-Hessian Newton solvers; Cholesky/CG require positive_semidefinite_tag,
+    # TruncatedCG / use_steihaug=True handle indefinite Hessians without it.
+    optx.LineSearchNewton(rtol, atol),
+    optx.LineSearchNewton(rtol, atol, linear_solver=lx.CG(rtol=1e-6, atol=0.0)),
+    optx.LineSearchNewton(rtol, atol, linear_solver=optx.TruncatedCG(rtol=0.5, atol=0.0)),
+    optx.TrustNewton(rtol, atol),
+    optx.TrustNewton(rtol, atol, linear_solver=lx.CG(rtol=1e-6, atol=0.0)),
+    optx.TrustNewton(rtol, atol, use_steihaug=True),
 )
 
 _minim_only = (
@@ -416,6 +424,16 @@ def square_minus_one(x: Array, args: PyTree):
     return jnp.sum(jnp.square(x)) - 1.0
 
 
+def globally_convex(y: Array, scale: Array) -> Scalar:
+    """Non-quadratic globally convex function: f(y) = Σ cosh(scale_i * y_i) − 1.
+
+    Hessian H = diag(scale^2 * cosh(scale*y)) > 0 everywhere for any scale > 0.
+    Unique minimum at y = 0, f* = 0, regardless of scale.
+    Passing scale as args gives a non-trivial (but still SPD) Hessian for testing.
+    """
+    return jnp.sum(jnp.cosh(scale * y) - 1)
+
+
 #
 # The MLP can be difficult for some of the solvers to optimise. Rather than set
 # max_steps to a higher value and iterate for longer, we initialise the MLP
@@ -559,7 +577,14 @@ minimisation_fn_minima_init_args = (
     ),
     # Problems with initial value of 0
     (square_minus_one, jnp.array(-1.0), jnp.array(1.0), None),
+    # Globally convex (PSD Hessian everywhere); used for Newton+Cholesky/CG tests.
+    (globally_convex, jnp.array(0.0), jnp.array([0.4, -0.3, 0.2]), jnp.ones(3)),
 )
+
+# Problems with a globally PSD Hessian; lx.CG-based Newton requires this.
+_spd_minimisation_fns = frozenset({bowl, matyas, square_minus_one, globally_convex})
+
+
 
 # ROOT FIND/FIXED POINT PROBLEMS
 #

--- a/tests/test_least_squares.py
+++ b/tests/test_least_squares.py
@@ -15,6 +15,7 @@ from .helpers import (
     finite_difference_jvp,
     least_squares_fn_minima_init_args,
     least_squares_optimisers,
+    _spd_minimisation_fns,
     rosenbrock,
     simple_nn,
     tree_allclose,
@@ -27,6 +28,10 @@ smoke_aux = (jnp.ones((2, 3)), {"smoke_aux": jnp.ones(2)})
 @pytest.mark.parametrize("solver", least_squares_optimisers)
 @pytest.mark.parametrize("_fn, minimum, init, args", least_squares_fn_minima_init_args)
 def test_least_squares(solver, _fn, minimum, init, args):
+    if isinstance(getattr(solver.descent, "linear_solver", None), lx.CG) and _fn not in _spd_minimisation_fns:
+        return
+    tags = frozenset({lx.positive_semidefinite_tag}) if _fn in _spd_minimisation_fns else frozenset()
+
     atol = rtol = 1e-4
     has_aux = random.choice([True, False])
     if has_aux:
@@ -40,7 +45,14 @@ def test_least_squares(solver, _fn, minimum, init, args):
         context = contextlib.nullcontext()
     with context:
         optx_argmin = optx.least_squares(
-            fn, solver, init, has_aux=has_aux, args=args, max_steps=10_000, throw=False
+            fn,
+            solver,
+            init,
+            has_aux=has_aux,
+            args=args,
+            max_steps=10_000,
+            throw=False,
+            tags=tags,
         ).value
     out = fn(optx_argmin, args)
     if has_aux:
@@ -59,6 +71,10 @@ def test_least_squares_jvp(getkey, solver, _fn, minimum, init, args):
     if _fn in (simple_nn, diagonal_quadratic_bowl):
         # These are ridiculously finickity to get references values for the derivatives
         return
+    if isinstance(getattr(solver.descent, "linear_solver", None), lx.CG) and _fn not in _spd_minimisation_fns:
+        return
+    tags = frozenset({lx.positive_semidefinite_tag}) if _fn in _spd_minimisation_fns else frozenset()
+
     atol = rtol = 1e-2
     has_aux = random.choice([True, False])
     if has_aux:
@@ -86,6 +102,7 @@ def test_least_squares_jvp(getkey, solver, _fn, minimum, init, args):
                 max_steps=10_000,
                 adjoint=adjoint,
                 throw=False,
+                tags=tags,
             ).value
 
     if _fn is simple_nn:

--- a/tests/test_least_squares.py
+++ b/tests/test_least_squares.py
@@ -11,11 +11,11 @@ import optimistix as optx
 import pytest
 
 from .helpers import (
+    _spd_minimisation_fns,
     diagonal_quadratic_bowl,
     finite_difference_jvp,
     least_squares_fn_minima_init_args,
     least_squares_optimisers,
-    _spd_minimisation_fns,
     rosenbrock,
     simple_nn,
     tree_allclose,
@@ -28,9 +28,16 @@ smoke_aux = (jnp.ones((2, 3)), {"smoke_aux": jnp.ones(2)})
 @pytest.mark.parametrize("solver", least_squares_optimisers)
 @pytest.mark.parametrize("_fn, minimum, init, args", least_squares_fn_minima_init_args)
 def test_least_squares(solver, _fn, minimum, init, args):
-    if isinstance(getattr(solver.descent, "linear_solver", None), lx.CG) and _fn not in _spd_minimisation_fns:
+    if (
+        isinstance(getattr(solver.descent, "linear_solver", None), lx.CG)
+        and _fn not in _spd_minimisation_fns
+    ):
         return
-    tags = frozenset({lx.positive_semidefinite_tag}) if _fn in _spd_minimisation_fns else frozenset()
+    tags = (
+        frozenset({lx.positive_semidefinite_tag})
+        if _fn in _spd_minimisation_fns
+        else frozenset()
+    )
 
     atol = rtol = 1e-4
     has_aux = random.choice([True, False])
@@ -71,9 +78,16 @@ def test_least_squares_jvp(getkey, solver, _fn, minimum, init, args):
     if _fn in (simple_nn, diagonal_quadratic_bowl):
         # These are ridiculously finickity to get references values for the derivatives
         return
-    if isinstance(getattr(solver.descent, "linear_solver", None), lx.CG) and _fn not in _spd_minimisation_fns:
+    if (
+        isinstance(getattr(solver.descent, "linear_solver", None), lx.CG)
+        and _fn not in _spd_minimisation_fns
+    ):
         return
-    tags = frozenset({lx.positive_semidefinite_tag}) if _fn in _spd_minimisation_fns else frozenset()
+    tags = (
+        frozenset({lx.positive_semidefinite_tag})
+        if _fn in _spd_minimisation_fns
+        else frozenset()
+    )
 
     atol = rtol = 1e-2
     has_aux = random.choice([True, False])

--- a/tests/test_minimise.py
+++ b/tests/test_minimise.py
@@ -36,7 +36,11 @@ smoke_aux = (jnp.ones((2, 3)), {"smoke_aux": jnp.ones(2)})
 @pytest.mark.parametrize("solver", minimisers)
 @pytest.mark.parametrize("_fn, minimum, init, args", minimisation_fn_minima_init_args)
 def test_minimise(solver, _fn, minimum, init, args, options):
-    if isinstance(getattr(solver.descent, "linear_solver", None), lx.CG) and _fn not in _spd_minimisation_fns:
+    descent = getattr(solver, "descent", None)
+    if (
+        isinstance(getattr(descent, "linear_solver", None), lx.CG)
+        and _fn not in _spd_minimisation_fns
+    ):
         return
     tags = (
         frozenset({lx.positive_semidefinite_tag})
@@ -80,7 +84,11 @@ def test_minimise(solver, _fn, minimum, init, args, options):
 @pytest.mark.parametrize("solver", minimisers)
 @pytest.mark.parametrize("_fn, minimum, init, args", minimisation_fn_minima_init_args)
 def test_minimise_jvp(getkey, solver, _fn, minimum, init, args, options):
-    if isinstance(getattr(solver.descent, "linear_solver", None), lx.CG) and _fn not in _spd_minimisation_fns:
+    descent = getattr(solver, "descent", None)
+    if (
+        isinstance(getattr(descent, "linear_solver", None), lx.CG)
+        and _fn not in _spd_minimisation_fns
+    ):
         return
     tags = (
         frozenset({lx.positive_semidefinite_tag})
@@ -229,7 +237,11 @@ def test_optax_recompilation():
 def test_forward_minimisation(fn, y0, options, expected, solver):
     if isinstance(solver, optx.OptaxMinimiser):  # No support for forward option
         return
-    elif isinstance(getattr(solver.descent, "linear_solver", None), lx.CG) and fn not in _spd_minimisation_fns:
+    descent = getattr(solver, "descent", None)
+    if (
+        isinstance(getattr(descent, "linear_solver", None), lx.CG)
+        and fn not in _spd_minimisation_fns
+    ):
         return
     else:
         tags = (

--- a/tests/test_minimise.py
+++ b/tests/test_minimise.py
@@ -7,15 +7,18 @@ import jax
 import jax.numpy as jnp
 import jax.random as jr
 import jax.tree_util as jtu
+import lineax as lx
 import optax
 import optimistix as optx
 import pytest
 
 from .helpers import (
+    _spd_minimisation_fns,
     beale,
     bowl,
     finite_difference_jvp,
     forward_only_fn_init_options_expected,
+    globally_convex,
     golden_search_fn_y0_options_expected,
     matyas,
     minimisation_fn_minima_init_args,
@@ -33,6 +36,14 @@ smoke_aux = (jnp.ones((2, 3)), {"smoke_aux": jnp.ones(2)})
 @pytest.mark.parametrize("solver", minimisers)
 @pytest.mark.parametrize("_fn, minimum, init, args", minimisation_fn_minima_init_args)
 def test_minimise(solver, _fn, minimum, init, args, options):
+    if isinstance(getattr(solver.descent, "linear_solver", None), lx.CG) and _fn not in _spd_minimisation_fns:
+        return
+    tags = (
+        frozenset({lx.positive_semidefinite_tag})
+        if _fn in _spd_minimisation_fns
+        else frozenset()
+    )
+
     if isinstance(solver, optx.GradientDescent):
         max_steps = 100_000
     else:
@@ -57,6 +68,7 @@ def test_minimise(solver, _fn, minimum, init, args, options):
             options=options,
             max_steps=max_steps,
             throw=False,
+            tags=tags,
         ).value
     optx_min = _fn(optx_argmin, args)
     assert tree_allclose(optx_min, minimum, atol=atol, rtol=rtol)
@@ -68,7 +80,15 @@ def test_minimise(solver, _fn, minimum, init, args, options):
 @pytest.mark.parametrize("solver", minimisers)
 @pytest.mark.parametrize("_fn, minimum, init, args", minimisation_fn_minima_init_args)
 def test_minimise_jvp(getkey, solver, _fn, minimum, init, args, options):
-    if isinstance(solver, (optx.GradientDescent, optx.NonlinearCG)):
+    if isinstance(getattr(solver.descent, "linear_solver", None), lx.CG) and _fn not in _spd_minimisation_fns:
+        return
+    tags = (
+        frozenset({lx.positive_semidefinite_tag})
+        if _fn in _spd_minimisation_fns
+        else frozenset()
+    )
+
+    if isinstance(solver, (optx.GradientDescent, optx.NonlinearCG, optx.NelderMead)):
         max_steps = 100_000
         atol = rtol = 1e-2
     else:
@@ -101,14 +121,16 @@ def test_minimise_jvp(getkey, solver, _fn, minimum, init, args, options):
                 max_steps=max_steps,
                 adjoint=adjoint,
                 throw=False,
+                tags=tags,
             ).value
 
     otd = optx.ImplicitAdjoint()
     out, t_out = eqx.filter_jit(ft.partial(eqx.filter_jvp, minimise))(
         (init, dynamic_args), (t_init, t_dynamic_args), adjoint=otd
     )
-    if _fn is bowl:
-        # Finite difference is very inaccurate on this problem.
+    if _fn in (bowl, globally_convex):
+        # The minimum y*=0 is independent of both init and args for these functions,
+        # so ImplicitAdjoint correctly gives zero tangent. FD is noisy here.
         expected_out = t_expected_out = jtu.tree_map(jnp.zeros_like, init)
     elif _fn in (beale, matyas):
         if isinstance(solver, optx.NonlinearCG):
@@ -207,9 +229,16 @@ def test_optax_recompilation():
 def test_forward_minimisation(fn, y0, options, expected, solver):
     if isinstance(solver, optx.OptaxMinimiser):  # No support for forward option
         return
+    elif isinstance(getattr(solver.descent, "linear_solver", None), lx.CG) and fn not in _spd_minimisation_fns:
+        return
     else:
+        tags = (
+            frozenset({lx.positive_semidefinite_tag})
+            if fn in _spd_minimisation_fns
+            else frozenset()
+        )
         # Many steps because gradient descent takes ridiculously long
-        sol = optx.minimise(fn, solver, y0, options=options, max_steps=2**10)
+        sol = optx.minimise(fn, solver, y0, options=options, max_steps=2**10, tags=tags)
         assert sol.result == optx.RESULTS.successful
         assert tree_allclose(sol.value, expected, atol=1e-4, rtol=1e-4)
 


### PR DESCRIPTION
Another (overrunning) weekend project, inspired by realising lineax doesn't really need a HessianLinearOperator. This is a giant PR so I fully appreciate it may take quite some time to review, iterate and merge this (assuming this is something you want to support in optimistix, understand if not). Consider this mostly a proof of concept to show what's possible, I am very open to feedback and opinions on API and design. Note this was written with a lot of LLM support and I didn't want to overly finesse the docs until final architecture is agreed upon and there might be some boilerplate/wiring code (especially in TruncatedCG) that needs further simplification/refactoring.

Note this was motivated by trying to come up with good examples for a Hessian linear operator on a lineax [issue discussion](https://github.com/patrick-kidger/lineax/issues/4). The key behind everything is the `_make_hessian_f_info` function everything else is just managing negative curvature, trust regions, performance, adding linear solvers to make sure this isn't a damp squib etc. Note that I never use `JacobianLinearOperator` but `FunctionLinearOperator` as I need to use `jax.linearize` to access the gradient value. Therefore a `hessian_linear_operator` would not actually be used here, the main use case for Hessians. We could of course just have the below function as helper in lineax `grad_and_hessian_op` or something but might be tricky to document and explain clearly.

```python
def _grad_hessian(
    fn: Fn[Y, Scalar, Aux],
    y: Y,
    args: PyTree,
    tags: frozenset[object],
    *,
    autodiff_mode: str = "bwd",
) -> tuple[Y, lx.FunctionLinearOperator]:
    """Return ``(grad, hessian_operator)`` at ``y``."""
    if autodiff_mode == "bwd":
        grad_fn = jax.grad(_NoAux(fn))
    else:
        grad_fn = jax.jacfwd(_NoAux(fn))
    grad, hvp_fn = jax.linearize(lambda _y: grad_fn(_y, args), y)
    hessian = lx.FunctionLinearOperator(
        hvp_fn, jax.eval_shape(lambda: y), frozenset({lx.symmetric_tag}) | tags
    )
    return grad, hessian
```

I believe this would make optimistix the **first jax library with true jittable second-order methods**, (pretty sure optax doesn't have any and jaxopt only has a non-accelerated wrapper of scipy.optimize.minimize).

### API

This PR offers two main points of entry:

**LineSearchNewton**

Uses NewtonDescent and BacktrackingArmijo linesearch with exact Hessian operator, uses steepest descent in regions of negative curvature.

**TrustNewton**

Uses ClassicalTrustRegion with either the new `SteihaugCGDescent` (to replicate scipy's trust-ncg) or `IndirectDampedNewtonDescent` (akin to scipy's trust-exact)

We also offer `AbstractNewtonMinimiser` to allow users to thread custom descents and searches (e.g. allowing a DoglegNewton like DoglegBFGS).

It also introduces a new linear solver **TruncatedCG** that detects negative curvature and is aware of trust regions. It can be used directly in `LineSearchNewton` (with `linear_solver=...` coming close to scipy's newton-cg) or indirectly by `TrustNewton` with `use_steihaug=True`.

### Summary of scipy mapping

`Newton-CG` -> `LineSearchNewton(linear_solver=TruncatedCG())` (Gaps: scipy uses Wolfe linesearch we use backtracking Armijo)

`trust-ncg` -> `TrustNewton(use_steihaug=True)` (pretty faithful implementation works even for non-SPD)

‘trust-exact’ -> Needs further development to properly support More-Sorensen but for SPD cases `solver=TrustNewton(linear_solver=lx.Cholesky()), tags=frozenset({lx.positive_semidefinite_tag})` should work pretty well

‘trust-krylov’ – **Not supported yet** requires even more complex linear solvers and wiring I believe

### Design

Created a new _AbstractNewtonBase which acts as a parent for _AbstractQuasiNewton and the new _AbstractNewtonMinimiser, all the child classes need to do is define `init` and `_prepare_step`.

### Performance

I have not bechmarked runtime/compile time but iteration wise these solvers beat all existing minimisers but typically lose against least square solvers. For a quadratic bowl all these solvers except for those that use TruncatedCG complete in 3 iterations (should be 1 but optimistix requires two steps for confirming Cauchy convergence but then only checks this at the beginning of the third step, we can experiment with pure gradient-based termination to improve if you're interested) where the best quasi-Newton solver (LBFGS) takes 48. TruncatedCG takes 5 iterations. For Beale/Himmelblau they converge in 6/8 iterations (although Steihaug takes 10 for Himmelblau) against 14/13 with the best quasi-Newton solver.

For completeness here are the **minimiser* comparisons:

```
Solver                          bowl  matyas   beale  himmelblau  sq_minus_one  glob_convex  glob_convex_far
------------------------------------------------------------------------------------------------------------
LineSearchNewton(Cholesky)         3       3       6           8             3            4               14
LineSearchNewton(TruncCG)          5       3       6           8             3            4               14
TrustNewton(Cholesky)              3       3       6           8             3            4               14
TrustNewton(Steihaug)              5       6       6          10             3            4               14
BFGS                              98       4      14          18             4            5               44
LBFGS                             48       4      15          13             4            5               26
```

And the **least square** comparisons:

```
Solver                        diag_bowl  rosenbrock_a  rosenbrock_b
-------------------------------------------------------------------
LineSearchNewton(Cholesky)           15            14            23
TrustNewton(Cholesky)                15            17            27
TrustNewton(Steihaug)                17            20            24
GaussNewton                          10             4             4
LevenbergMarquardt                  138            12            30
IndirectLevenbergMarquardt           10            14            19
BFGS                                 78            33            42
LBFGS                                31            30            43
```

### Questions

Assuming we want to support second-order methods, these questions come to mind first as things to iron out to get this pull ready.

1. What is your preferred API Surface

a) Make _AbstractNewtonMinimiser the only public API (with a better name) users can just plug and play with descents and searches.
b) (This PR)  Concretise on search type only: LineSearchNewton and TrustNewton
c) Concretise very specific solvers (e.g. NewtonCG, TrustNCG, TrustExact) and maybe add even more Abstract classes

If we go with b) there is currently a bit of a gotcha, `use_steihaug=True` ALWAYS uses `TruncatedCG` and requires `linear_solver` to be sentinel `_UNSET` and errors if it isn't.  As such having the `linear_solver` argument could be a bit confusing and separating Steihaug out as TrustNCG (option c) might be sensible.

2. What are your thoughts on including these as options in `optimistix.compat.minimize` (including those you already support)
3. Should we rename _QuasiNewtonState or create a parent class?
4. Have I made any mistakes with regards to reducing compilation overhead (while the total memory usage of test_minimize.py is now about ~8GB I didn't notice any large jumps or slow downs when running).
5. Would you rather TruncatedCG in optimistix or lineax?
6. Cholesky can sometimes succeed by luck in the non-SPD case, should we highlight that as a possibility to users or too much of a footgun?
7. I've added an iteration benchmark script for convenience, I'm intending to remove it when this PR is ready, let me know if you'd prefer to keep it.

**Tags**

* should we EXPLICITLY declare the default tags for ALL `_AbstractNewtonBase` minimisers to be is_symmetric (should be generally true), or just silently thread it in as I am doing currently in `_grad_hessian
* damped_newton_step currently only tags the Hessian as SPD when the initial Hessian is tagged as SPD, however, if the root find is successful then it is guaranteed to be SPD in any case because the damping is sufficient to make it SPD. Do you want to handle that case any differently?

**Future Linear Solvers (out of scope for this PR)**

LineSearchNewton would arguably benefit from a More-Sorensen approach such as ModifiedCholesky or ModifiedLDL, let me know how keen you are in having those in optimistix/lineax. I am currently working on exposing sytrf in jax to support LDL, but it performs pretty poorly on GPU compared to LU.