### PR TITLE
refactor line-search solvers to return latest iterate

### DIFF
--- a/optimistix/_solver/gauss_newton.py
+++ b/optimistix/_solver/gauss_newton.py
@@ -18,7 +18,6 @@ from .._misc import (
     max_norm,
     sum_squares,
     tree_full_like,
-    tree_where,
 )
 from .._search import (
     AbstractDescent,
@@ -140,7 +139,7 @@ NewtonDescent.__init__.__doc__ = """**Arguments:**
 class _GaussNewtonState(eqx.Module, Generic[Y, Out, Aux, SearchState, DescentState]):
     # Updated every search step
     first_step: Bool[Array, ""]
-    y_eval: Y
+    y_accepted: Y
     search_state: SearchState
     # Updated after each descent step
     f_info: FunctionInfo.ResidualJac
@@ -228,7 +227,7 @@ class AbstractGaussNewton(AbstractLeastSquaresSolver[Y, Out, Aux, _GaussNewtonSt
         f_info = tree_full_like(f_info_struct, 0, allow_static=True)
         return _GaussNewtonState(
             first_step=jnp.array(True),
-            y_eval=y,
+            y_accepted=y,
             search_state=self.search.init(y, f_info_struct),
             f_info=f_info,
             aux=tree_full_like(aux_struct, 0),
@@ -250,7 +249,7 @@ class AbstractGaussNewton(AbstractLeastSquaresSolver[Y, Out, Aux, _GaussNewtonSt
         tags: frozenset[object],
     ) -> tuple[Y, _GaussNewtonState, Aux]:
         jac = options.get("jac", "fwd")
-        f_eval_info, aux_eval = _make_f_info(fn, state.y_eval, args, tags, jac)
+        f_eval_info, aux_eval = _make_f_info(fn, y, args, tags, jac)
         # We have a jaxpr in `f_info.jac`, which are compared by identity. Here we
         # arrange to use the same one so that downstream equality checks (e.g. in the
         # `filter_cond` below)
@@ -261,8 +260,8 @@ class AbstractGaussNewton(AbstractLeastSquaresSolver[Y, Out, Aux, _GaussNewtonSt
 
         step_size, accept, search_result, search_state = self.search.step(
             state.first_step,
+            state.y_accepted,
             y,
-            state.y_eval,
             state.f_info,
             f_eval_info,
             state.search_state,
@@ -274,24 +273,24 @@ class AbstractGaussNewton(AbstractLeastSquaresSolver[Y, Out, Aux, _GaussNewtonSt
         )
 
         def accepted(descent_state):
-            descent_state = self.descent.query(state.y_eval, f_eval_info, descent_state)
-            y_diff = (state.y_eval**ω - y**ω).ω
+            descent_state = self.descent.query(y, f_eval_info, descent_state)
+            y_diff = (y**ω - state.y_accepted**ω).ω
             f_diff = (f_eval_info.residual**ω - state.f_info.residual**ω).ω
             terminate = cauchy_termination(
                 self.rtol,
                 self.atol,
                 self.norm,
-                state.y_eval,
+                y,
                 y_diff,
                 f_eval_info.residual,
                 f_diff,
             )
-            return state.y_eval, f_eval_info, aux_eval, descent_state, terminate
+            return y, f_eval_info, aux_eval, descent_state, terminate
 
         def rejected(descent_state):
-            return y, state.f_info, state.aux, descent_state, jnp.array(False)
+            return state.y_accepted, state.f_info, state.aux, descent_state, jnp.array(False)
 
-        y, f_info, aux, descent_state, terminate = filter_cond(
+        accepted_y, f_info, aux, descent_state, terminate = filter_cond(
             accept, accepted, rejected, state.descent_state
         )
 
@@ -307,20 +306,19 @@ class AbstractGaussNewton(AbstractLeastSquaresSolver[Y, Out, Aux, _GaussNewtonSt
             loss_this_step=("Loss on this step", loss_eval),
             loss_last_accepted_step=("Loss on the last accepted step", loss),
             step_size=("Step size", step_size),
-            y=("y", state.y_eval),
-            y_last_accepted_step=("y on the last accepted step", y),
+            y=("y", y),
+            y_last_accepted_step=("y on the last accepted step", state.y_accepted),
         )
 
         y_descent, descent_result = self.descent.step(step_size, descent_state)
-        y_eval = (y**ω + y_descent**ω).ω
+        y_eval = (accepted_y**ω + y_descent**ω).ω
         result = RESULTS.where(
             search_result == RESULTS.successful, descent_result, search_result
         )
 
-        prev_aux = tree_where(state.first_step, aux, state.aux)
         state = _GaussNewtonState(
             first_step=jnp.array(False),
-            y_eval=y_eval,
+            y_accepted=accepted_y,
             search_state=search_state,
             f_info=f_info,
             aux=aux,
@@ -331,7 +329,7 @@ class AbstractGaussNewton(AbstractLeastSquaresSolver[Y, Out, Aux, _GaussNewtonSt
             num_accepted_steps=num_accepted_steps,
             num_steps_since_acceptance=num_steps_since_acceptance,
         )
-        return y, state, prev_aux
+        return y_eval, state, aux_eval
 
     def terminate(
         self,
@@ -355,7 +353,7 @@ class AbstractGaussNewton(AbstractLeastSquaresSolver[Y, Out, Aux, _GaussNewtonSt
         tags: frozenset[object],
         result: RESULTS,
     ) -> tuple[Y, Aux, dict[str, Any]]:
-        return y, aux, {}
+        return state.y_accepted, state.aux, {}
 
 
 class GaussNewton(AbstractGaussNewton[Y, Out, Aux]):

--- a/optimistix/_solver/gauss_newton.py
+++ b/optimistix/_solver/gauss_newton.py
@@ -288,7 +288,13 @@ class AbstractGaussNewton(AbstractLeastSquaresSolver[Y, Out, Aux, _GaussNewtonSt
             return y, f_eval_info, aux_eval, descent_state, terminate
 
         def rejected(descent_state):
-            return state.y_accepted, state.f_info, state.aux, descent_state, jnp.array(False)
+            return (
+                state.y_accepted,
+                state.f_info,
+                state.aux,
+                descent_state,
+                jnp.array(False),
+            )
 
         accepted_y, f_info, aux, descent_state, terminate = filter_cond(
             accept, accepted, rejected, state.descent_state

--- a/optimistix/_solver/gradient_methods.py
+++ b/optimistix/_solver/gradient_methods.py
@@ -16,7 +16,6 @@ from .._misc import (
     lin_to_grad,
     max_norm,
     tree_full_like,
-    tree_where,
 )
 from .._search import (
     AbstractDescent,
@@ -93,7 +92,7 @@ class _GradientDescentState(
 ):
     # Updated every search step
     first_step: Bool[Array, ""]
-    y_eval: Y
+    y_accepted: Y
     search_state: SearchState
     # Updated after each descent step
     f_info: FunctionInfo.EvalGrad
@@ -149,7 +148,7 @@ class AbstractGradientDescent(AbstractMinimiser[Y, Aux, _GradientDescentState]):
         f_info_struct = jax.eval_shape(lambda: f_info)
         return _GradientDescentState(
             first_step=jnp.array(True),
-            y_eval=y,
+            y_accepted=y,
             search_state=self.search.init(y, f_info_struct),
             f_info=f_info,
             aux=tree_full_like(aux_struct, 0),
@@ -169,49 +168,48 @@ class AbstractGradientDescent(AbstractMinimiser[Y, Aux, _GradientDescentState]):
     ) -> tuple[Y, _GradientDescentState, Aux]:
         autodiff_mode = options.get("autodiff_mode", "bwd")
         f_eval, lin_fn, aux_eval = jax.linearize(
-            lambda _y: fn(_y, args), state.y_eval, has_aux=True
+            lambda _y: fn(_y, args), y, has_aux=True
         )
         step_size, accept, search_result, search_state = self.search.step(
             state.first_step,
+            state.y_accepted,
             y,
-            state.y_eval,
             state.f_info,
             FunctionInfo.Eval(f_eval),
             state.search_state,
         )
 
         def accepted(descent_state):
-            grad = lin_to_grad(lin_fn, state.y_eval, autodiff_mode, f_eval.dtype)
+            grad = lin_to_grad(lin_fn, y, autodiff_mode, f_eval.dtype)
 
             f_eval_info = FunctionInfo.EvalGrad(f_eval, grad)
-            descent_state = self.descent.query(state.y_eval, f_eval_info, descent_state)
-            y_diff = (state.y_eval**ω - y**ω).ω
+            descent_state = self.descent.query(y, f_eval_info, descent_state)
+            y_diff = (y**ω - state.y_accepted**ω).ω
             f_diff = (f_eval**ω - state.f_info.f**ω).ω
             terminate = cauchy_termination(
-                self.rtol, self.atol, self.norm, state.y_eval, y_diff, f_eval, f_diff
+                self.rtol, self.atol, self.norm, y, y_diff, f_eval, f_diff
             )
             terminate = jnp.where(
                 state.first_step, jnp.array(False), terminate
             )  # Skip termination on first step
-            return state.y_eval, f_eval_info, aux_eval, descent_state, terminate
+            return y, f_eval_info, aux_eval, descent_state, terminate
 
         def rejected(descent_state):
-            return y, state.f_info, state.aux, descent_state, jnp.array(False)
+            return state.y_accepted, state.f_info, state.aux, descent_state, jnp.array(False)
 
-        y, f_info, aux, descent_state, terminate = filter_cond(
+        accepted_y, f_info, aux, descent_state, terminate = filter_cond(
             accept, accepted, rejected, state.descent_state
         )
 
         y_descent, descent_result = self.descent.step(step_size, descent_state)
-        y_eval = (y**ω + y_descent**ω).ω
+        y_eval = (accepted_y**ω + y_descent**ω).ω
         result = RESULTS.where(
             search_result == RESULTS.successful, descent_result, search_result
         )
 
-        prev_aux = tree_where(state.first_step, aux, state.aux)
         state = _GradientDescentState(
             first_step=jnp.array(False),
-            y_eval=y_eval,
+            y_accepted=accepted_y,
             search_state=search_state,
             f_info=f_info,
             aux=aux,
@@ -219,7 +217,7 @@ class AbstractGradientDescent(AbstractMinimiser[Y, Aux, _GradientDescentState]):
             terminate=terminate,
             result=result,
         )
-        return y, state, prev_aux
+        return y_eval, state, aux_eval
 
     def terminate(
         self,
@@ -243,7 +241,7 @@ class AbstractGradientDescent(AbstractMinimiser[Y, Aux, _GradientDescentState]):
         tags: frozenset[object],
         result: RESULTS,
     ) -> tuple[Y, Aux, dict[str, Any]]:
-        return y, aux, {}
+        return state.y_accepted, state.aux, {}
 
 
 class GradientDescent(AbstractGradientDescent[Y, Aux]):

--- a/optimistix/_solver/gradient_methods.py
+++ b/optimistix/_solver/gradient_methods.py
@@ -195,7 +195,13 @@ class AbstractGradientDescent(AbstractMinimiser[Y, Aux, _GradientDescentState]):
             return y, f_eval_info, aux_eval, descent_state, terminate
 
         def rejected(descent_state):
-            return state.y_accepted, state.f_info, state.aux, descent_state, jnp.array(False)
+            return (
+                state.y_accepted,
+                state.f_info,
+                state.aux,
+                descent_state,
+                jnp.array(False),
+            )
 
         accepted_y, f_info, aux, descent_state, terminate = filter_cond(
             accept, accepted, rejected, state.descent_state

--- a/optimistix/_solver/quasi_newton.py
+++ b/optimistix/_solver/quasi_newton.py
@@ -21,7 +21,6 @@ from .._misc import (
     max_norm,
     tree_dot,
     tree_full_like,
-    tree_where,
 )
 from .._search import (
     AbstractDescent,
@@ -88,7 +87,7 @@ class _QuasiNewtonState(
 ):
     # Updated every search step
     first_step: Bool[Array, ""]
-    y_eval: Y
+    y_accepted: Y
     search_state: SearchState
     # Updated after each descent step
     f_info: _Hessian
@@ -190,7 +189,7 @@ class AbstractQuasiNewton(
 
         return _QuasiNewtonState(
             first_step=jnp.array(True),
-            y_eval=y,
+            y_accepted=y,
             search_state=self.search.init(y, f_info_struct),
             f_info=f_info,
             aux=tree_full_like(aux_struct, 0),
@@ -212,43 +211,43 @@ class AbstractQuasiNewton(
     ) -> tuple[Y, _QuasiNewtonState, Aux]:
         autodiff_mode = options.get("autodiff_mode", "bwd")
         f_eval, lin_fn, aux_eval = jax.linearize(
-            lambda _y: fn(_y, args), state.y_eval, has_aux=True
+            lambda _y: fn(_y, args), y, has_aux=True
         )
         step_size, accept, search_result, search_state = self.search.step(
             state.first_step,
+            state.y_accepted,
             y,
-            state.y_eval,
             state.f_info,
             FunctionInfo.Eval(f_eval),
             state.search_state,
         )
 
         def accepted(descent_state):
-            grad = lin_to_grad(lin_fn, state.y_eval, autodiff_mode, f_eval.dtype)
+            grad = lin_to_grad(lin_fn, y, autodiff_mode, f_eval.dtype)
 
             f_eval_info, hessian_update_state = self.update_hessian(
+                state.y_accepted,
                 y,
-                state.y_eval,
                 state.f_info,
                 FunctionInfo.EvalGrad(f_eval, grad),
                 state.hessian_update_state,
             )
 
             descent_state = self.descent.query(
-                state.y_eval,
+                y,
                 f_eval_info,  # pyright: ignore
                 descent_state,
             )
-            y_diff = (state.y_eval**ω - y**ω).ω
+            y_diff = (y**ω - state.y_accepted**ω).ω
             f_diff = (f_eval**ω - state.f_info.f**ω).ω
             terminate = cauchy_termination(
-                self.rtol, self.atol, self.norm, state.y_eval, y_diff, f_eval, f_diff
+                self.rtol, self.atol, self.norm, y, y_diff, f_eval, f_diff
             )
             terminate = jnp.where(
                 state.first_step, jnp.array(False), terminate
             )  # Skip termination on first step
             return (
-                state.y_eval,
+                y,
                 f_eval_info,
                 aux_eval,
                 descent_state,
@@ -258,7 +257,7 @@ class AbstractQuasiNewton(
 
         def rejected(descent_state):
             return (
-                y,
+                state.y_accepted,
                 state.f_info,
                 state.aux,
                 descent_state,
@@ -266,28 +265,27 @@ class AbstractQuasiNewton(
                 state.hessian_update_state,
             )
 
-        y, f_info, aux, descent_state, terminate, hessian_update_state = filter_cond(
-            accept, accepted, rejected, state.descent_state
+        accepted_y, f_info, aux, descent_state, terminate, hessian_update_state = (
+            filter_cond(accept, accepted, rejected, state.descent_state)
         )
 
         self.verbose(
             loss_this_step=("Loss on this step", f_eval),
             loss_last_accepted_step=("Loss on the last accepted step", state.f_info.f),
             step_size=("Step size", step_size),
-            y=("y", state.y_eval),
-            y_last_accepted_step=("y on the last accepted step", y),
+            y=("y", y),
+            y_last_accepted_step=("y on the last accepted step", state.y_accepted),
         )
 
         y_descent, descent_result = self.descent.step(step_size, descent_state)
-        y_eval = (y**ω + y_descent**ω).ω
+        y_eval = (accepted_y**ω + y_descent**ω).ω
         result = RESULTS.where(
             search_result == RESULTS.successful, descent_result, search_result
         )
 
-        prev_aux = tree_where(state.first_step, aux, state.aux)
         state = _QuasiNewtonState(
             first_step=jnp.array(False),
-            y_eval=y_eval,
+            y_accepted=accepted_y,
             search_state=search_state,
             f_info=f_info,
             aux=aux,
@@ -297,7 +295,7 @@ class AbstractQuasiNewton(
             num_accepted_steps=state.num_accepted_steps + jnp.where(accept, 1, 0),
             hessian_update_state=hessian_update_state,
         )
-        return y, state, prev_aux
+        return y_eval, state, aux_eval
 
     def terminate(
         self,
@@ -321,7 +319,7 @@ class AbstractQuasiNewton(
         tags: frozenset[object],
         result: RESULTS,
     ) -> tuple[Y, Aux, dict[str, Any]]:
-        return y, aux, {}
+        return state.y_accepted, state.aux, {}
 
 
 class AbstractBFGS(AbstractQuasiNewton[Y, Aux, _Hessian, None]):


### PR DESCRIPTION
As suggested in your [comment](https://github.com/patrick-kidger/optimistix/pull/225#issuecomment-4126518747) in #225, I have refactored line-search solvers, specifically `AbstractGradientDescent`, `AbstractQuasiNewton` and `AbstractGaussNewton` (and their subclasses implicitly), such that `step` always receives and returns the latest iterate rather than the last accepted step. The last accepted step is now stored in `state.y_accepted` instead of `state.y_eval`. This means we don't have to use `tree_where` to construct `prev_aux` anymore and all minimisers and least square solvers compose with `BestSoFarMinimiser` in the same way—including the very latest iterate in the sequence rather than the lagged accepted. Note that this means that the `y` returned will be worse than `y_accepted` on rejected steps, but as `BestSoFarMinimiser` sees all iterates this is not an issue.

Once this is merged I can have a think about whether a wider unification of line-search solvers is possible.