### PR TITLE
fix reporting nonconvergence as divergence for non-Cauchy termination

### DIFF
--- a/optimistix/_solver/newton_chord.py
+++ b/optimistix/_solver/newton_chord.py
@@ -186,7 +186,7 @@ class _AbstractNewtonChord(AbstractRootFinder[Y, Out, Aux, _NewtonChordState[Y]]
             converged = _converged(factor, self.kappa)
             terminate = at_least_two & (small | diverged | converged)
             terminate_result = RESULTS.where(
-                at_least_two & jnp.invert(small) & (diverged | jnp.invert(converged)),
+                at_least_two & jnp.invert(small) & diverged,
                 RESULTS.nonlinear_divergence,
                 RESULTS.successful,
             )


### PR DESCRIPTION
This would fix #221  if VeryChord subclassed AbstractNewtonChord but it doesn't, as such I will need to mirror this in a diffrax PR. Note the step counts only reduce from 845 to 242 rather than 238 simply because `at_least_two` is now doing what it shold.